### PR TITLE
example config: removed trailing comma

### DIFF
--- a/config/example.json
+++ b/config/example.json
@@ -37,7 +37,7 @@
       "function_copy_idx": 0,
       "repetitions": 5,
       "sleep": 1
-    },
+    }
   },
   "deployment": {
     "name": "aws",


### PR DESCRIPTION
json parsing of that file failed on several machines