### PR TITLE
sebs/aws/config.py: in arn creation for http api gateway the region i…

### DIFF
--- a/sebs/aws/config.py
+++ b/sebs/aws/config.py
@@ -179,7 +179,7 @@ class AWSResources(Resources):
             # easier than querying AWS resources to get account id
             account_id = func.arn.split(":")[4]
             # API arn is:
-            arn = f"arn:aws:execute-api:us-east-1:{account_id}:{api_id}"
+            arn = f"arn:aws:execute-api:{self._region}:{account_id}:{api_id}"
             http_api = AWSResources.HTTPApi(arn, endpoint)
             self._http_apis[api_name] = http_api
         else:


### PR DESCRIPTION
…s hardcoded to us-east-1

changed it to self._region so it works with config in which eu-central-1 is configured