### PR TITLE
Catch gcp HttpError

### DIFF
--- a/sebs/gcp/gcp.py
+++ b/sebs/gcp/gcp.py
@@ -204,7 +204,7 @@ class GCP(System):
         get_req = self.function_client.projects().locations().functions().get(name=full_func_name)
         
         try:
-            get_result = get_req.execute()
+            get_req.execute()
         except HttpError:
             create_req = (
                 self.function_client.projects()
@@ -252,7 +252,7 @@ class GCP(System):
         else:
             # if result is not empty, then function does exists
             self.logging.info("Function {} exists on GCP, update the instance.".format(func_name))
-            
+
             function = GCPFunction(
                 name=func_name,
                 benchmark=benchmark,

--- a/sebs/gcp/gcp.py
+++ b/sebs/gcp/gcp.py
@@ -10,6 +10,7 @@ from datetime import datetime, timezone
 from typing import cast, Dict, Optional, Tuple, List, Type
 
 from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
 from google.cloud import monitoring_v3
 
 from sebs.cache import Cache
@@ -201,23 +202,10 @@ class GCP(System):
 
         full_func_name = GCP.get_full_function_name(project_name, location, func_name)
         get_req = self.function_client.projects().locations().functions().get(name=full_func_name)
-        get_result = get_req.execute()
-
-        language_runtime = (code_package.language_name + language_runtime.replace(".", ""),)
-
-        # if result is not empty, then function does exists
-        if get_result:
-            self.logging.info("Function {} exists on GCP, update the instance.".format(func_name))
-            function = GCPFunction(
-                name=func_name,
-                benchmark=benchmark,
-                code_package_hash=code_package.hash,
-                timeout=timeout,
-                memory=memory,
-                bucket=code_bucket,
-            )
-            self.update_function(function, code_package)
-        else:
+        
+        try:
+            get_result = get_req.execute()
+        except HttpError:
             create_req = (
                 self.function_client.projects()
                 .locations()
@@ -261,6 +249,19 @@ class GCP(System):
             function = GCPFunction(
                 func_name, benchmark, code_package.hash, timeout, memory, code_bucket
             )
+        else:
+            # if result is not empty, then function does exists
+            self.logging.info("Function {} exists on GCP, update the instance.".format(func_name))
+            
+            function = GCPFunction(
+                name=func_name,
+                benchmark=benchmark,
+                code_package_hash=code_package.hash,
+                timeout=timeout,
+                memory=memory,
+                bucket=code_bucket,
+            )
+            self.update_function(function, code_package)
 
         # Add LibraryTrigger to a new function
         from sebs.gcp.triggers import LibraryTrigger

--- a/sebs/gcp/gcp.py
+++ b/sebs/gcp/gcp.py
@@ -202,7 +202,7 @@ class GCP(System):
 
         full_func_name = GCP.get_full_function_name(project_name, location, func_name)
         get_req = self.function_client.projects().locations().functions().get(name=full_func_name)
-        
+
         try:
             get_req.execute()
         except HttpError:


### PR DESCRIPTION
`execute` now raises an `HttpError` if the function does not exist yet. This fix excepts this error accordingly.