### PR TITLE
Fix #111 - incorrect igraph version

### DIFF
--- a/benchmarks/500.scientific/501.graph-pagerank/python/requirements.txt
+++ b/benchmarks/500.scientific/501.graph-pagerank/python/requirements.txt
@@ -1,1 +1,0 @@
-python-igraph==0.8.0

--- a/benchmarks/500.scientific/501.graph-pagerank/python/requirements.txt
+++ b/benchmarks/500.scientific/501.graph-pagerank/python/requirements.txt
@@ -1,1 +1,1 @@
-python-igraph==0.7.1.post6
+python-igraph==0.8.0

--- a/benchmarks/500.scientific/501.graph-pagerank/python/requirements.txt.3.7
+++ b/benchmarks/500.scientific/501.graph-pagerank/python/requirements.txt.3.7
@@ -1,0 +1,1 @@
+python-igraph==0.8.0

--- a/benchmarks/500.scientific/501.graph-pagerank/python/requirements.txt.3.8
+++ b/benchmarks/500.scientific/501.graph-pagerank/python/requirements.txt.3.8
@@ -1,0 +1,1 @@
+python-igraph==0.8.0

--- a/benchmarks/500.scientific/501.graph-pagerank/python/requirements.txt.3.9
+++ b/benchmarks/500.scientific/501.graph-pagerank/python/requirements.txt.3.9
@@ -1,0 +1,1 @@
+python-igraph==0.9.0

--- a/benchmarks/500.scientific/502.graph-mst/python/requirements.txt
+++ b/benchmarks/500.scientific/502.graph-mst/python/requirements.txt
@@ -1,1 +1,0 @@
-python-igraph==0.8.0

--- a/benchmarks/500.scientific/502.graph-mst/python/requirements.txt
+++ b/benchmarks/500.scientific/502.graph-mst/python/requirements.txt
@@ -1,1 +1,1 @@
-python-igraph==0.7.1.post6
+python-igraph==0.8.0

--- a/benchmarks/500.scientific/502.graph-mst/python/requirements.txt.3.7
+++ b/benchmarks/500.scientific/502.graph-mst/python/requirements.txt.3.7
@@ -1,0 +1,1 @@
+python-igraph==0.8.0

--- a/benchmarks/500.scientific/502.graph-mst/python/requirements.txt.3.8
+++ b/benchmarks/500.scientific/502.graph-mst/python/requirements.txt.3.8
@@ -1,0 +1,1 @@
+python-igraph==0.8.0

--- a/benchmarks/500.scientific/502.graph-mst/python/requirements.txt.3.9
+++ b/benchmarks/500.scientific/502.graph-mst/python/requirements.txt.3.9
@@ -1,0 +1,1 @@
+python-igraph==0.9.0

--- a/benchmarks/500.scientific/503.graph-bfs/python/requirements.txt
+++ b/benchmarks/500.scientific/503.graph-bfs/python/requirements.txt
@@ -1,1 +1,0 @@
-python-igraph==0.8.0

--- a/benchmarks/500.scientific/503.graph-bfs/python/requirements.txt
+++ b/benchmarks/500.scientific/503.graph-bfs/python/requirements.txt
@@ -1,1 +1,1 @@
-python-igraph==0.7.1.post6
+python-igraph==0.8.0

--- a/benchmarks/500.scientific/503.graph-bfs/python/requirements.txt.3.7
+++ b/benchmarks/500.scientific/503.graph-bfs/python/requirements.txt.3.7
@@ -1,0 +1,1 @@
+python-igraph==0.8.0

--- a/benchmarks/500.scientific/503.graph-bfs/python/requirements.txt.3.8
+++ b/benchmarks/500.scientific/503.graph-bfs/python/requirements.txt.3.8
@@ -1,0 +1,1 @@
+python-igraph==0.8.0

--- a/benchmarks/500.scientific/503.graph-bfs/python/requirements.txt.3.9
+++ b/benchmarks/500.scientific/503.graph-bfs/python/requirements.txt.3.9
@@ -1,0 +1,1 @@
+python-igraph==0.9.0


### PR DESCRIPTION
The version of igraph that we were using - 0.7.1 - was too old and caused issues after updating Python versions and underlying containers for the local deployment.

To finish the pull request, we need to verify that it does not impact the cloud deployment.