### PR TITLE
Fix shutdown and handling of memory measurement

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -154,3 +154,16 @@ To stop containers, you can use the following command:
 
 The stopped containers won't be automatically removed unless the option `--remove-containers` has been passed to the `start` command.
 
+#### Memory Measurements
+
+The local backend allows additional continuous measurement of function containers. At the moment,
+we support memory measurements. To enable this, pass the following flag to `./sebs.py local start`
+
+```
+--measure-interval <val>
+```
+
+The value specifies the time between two consecutive measurements. Measurements will be aggregated
+and written to a file when calling `./sebs.py local stop <file>`. By default, the data is written
+to `memory_stats.json`.
+

--- a/sebs.py
+++ b/sebs.py
@@ -397,8 +397,8 @@ def start(benchmark, benchmark_input_size, output, deployments, measure_interval
     )
     deployment_client = cast(sebs.local.Local, deployment_client)
     deployment_client.remove_containers = remove_containers
-    deployment_client.measure_interval = measure_interval
     result = sebs.local.Deployment()
+    result.measurement_file = deployment_client.start_measurements(measure_interval)
 
     experiment_config = sebs_client.get_experiment_config(config["experiments"])
     benchmark_obj = sebs_client.get_benchmark(
@@ -411,8 +411,6 @@ def start(benchmark, benchmark_input_size, output, deployments, measure_interval
     result.set_storage(storage)
     input_config = benchmark_obj.prepare_input(storage=storage, size=benchmark_input_size)
     result.add_input(input_config)
-
-    deployment_client.start_measurements(result)
 
     for i in range(deployments):
         func = deployment_client.get_function(

--- a/sebs.py
+++ b/sebs.py
@@ -6,8 +6,6 @@ import logging
 import functools
 import os
 import traceback
-import subprocess
-from statistics import mean
 from typing import cast, Optional
 
 import click
@@ -409,16 +407,12 @@ def start(benchmark, benchmark_input_size, output, deployments, measure_interval
         experiment_config,
         logging_filename=logging_filename,
     )
-    # initialize an empty file for measurements to be written to
-    subprocess.Popen("touch measurements_temp_file.txt && echo \"\" > measurements_temp_file.txt",
-                        shell=True)
     storage = deployment_client.get_storage(replace_existing=experiment_config.update_storage)
     result.set_storage(storage)
     input_config = benchmark_obj.prepare_input(storage=storage, size=benchmark_input_size)
     result.add_input(input_config)
 
-    if measure_interval >= 0:
-        result.add_memory_measurements(deployment_client.measure_processes)
+    deployment_client.start_measurements(result)
 
     for i in range(deployments):
         func = deployment_client.get_function(
@@ -444,54 +438,9 @@ def stop(input_json, output_json, **kwargs):
 
     sebs.utils.global_logging()
 
-    # kill measuring processes
-    with open(input_json, "r") as file:
-        procs = json.load(file)["memory_measurements"]
-        for proc in procs:
-            subprocess.Popen(f"kill {proc}", shell=True)
-
-    # create dictionary with the measurements
-    measurements = {}
-    precision_errors = 0
-    with open("measurements_temp_file.txt", "r") as file:
-        for line in file:
-            if line == "precision not met\n":
-                precision_errors += 1
-
-            line = line.split()
-            if len(line) == 0:
-                continue
-            if not line[0] in measurements:
-                try:
-                    measurements[line[0]] = [int(line[1])]
-                except:
-                    continue
-            else:
-                try:
-                    measurements[line[0]].append(int(line[1]))
-                except:
-                    continue
-
-    for container in measurements:
-        measurements[container] = {
-            "mean mem. usage" : f"{mean(measurements[container])/1e6} MB",
-            "max mem. usage" : f"{max(measurements[container])/1e6} MB",
-            "number of measurements" : len(measurements[container]),
-            "full profile (in bytes)" : measurements[container]
-        }
-
-    # write to output_json file
-    with open(output_json, "w") as out:
-        if precision_errors > 0:
-            out.write(f"Precision could not be met in {precision_errors} cases. Try using a longer measure interval.\n")
-        json.dump(measurements, out, indent=6)
-
-    # remove the temporary file the measurements were written to
-    subprocess.Popen("rm measurements_temp_file.txt", shell=True)
-
     logging.info(f"Stopping deployment from {os.path.abspath(input_json)}")
     deployment = sebs.local.Deployment.deserialize(input_json, None)
-    deployment.shutdown()
+    deployment.shutdown(output_json)
     logging.info(f"Stopped deployment from {os.path.abspath(input_json)}")
 
 

--- a/sebs/local/deployment.py
+++ b/sebs/local/deployment.py
@@ -1,5 +1,7 @@
 import json
-import subprocess
+import logging
+import os
+from signal import SIGKILL
 from statistics import mean
 from typing import List, Optional
 
@@ -60,9 +62,11 @@ class Deployment:
 
         if len(self._memory_measurement_pids) > 0:
 
+            logging.info("Killing memory measurement processes")
+
             # kill measuring processes
             for proc in self._memory_measurement_pids:
-                subprocess.Popen(f"kill {proc}", shell=True)
+                os.kill(proc, SIGKILL)
 
             # create dictionary with the measurements
             measurements: dict = {}
@@ -94,6 +98,7 @@ class Deployment:
                     "full profile (in bytes)": measurements[container],
                 }
 
+            logging.info(f"Gathering memory measurement data in {output_json}")
             # write to output_json file
             with open(output_json, "w") as out:
                 if precision_errors > 0:
@@ -101,7 +106,7 @@ class Deployment:
                 json.dump(measurements, out, indent=6)
 
             # remove the temporary file the measurements were written to
-            subprocess.Popen("rm measurements_temp_file.txt", shell=True)
+            os.remove("measurements_temp_file.txt")
 
         for func in self._functions:
             func.stop()

--- a/sebs/local/deployment.py
+++ b/sebs/local/deployment.py
@@ -1,4 +1,6 @@
 import json
+import subprocess
+from statistics import mean
 from typing import List, Optional
 
 from sebs.cache import Cache
@@ -12,19 +14,18 @@ class Deployment:
         self._functions: List[LocalFunction] = []
         self._storage: Optional[Minio]
         self._inputs: List[dict] = []
-        self._memory_measurements: Optional[List[int]] = None
+        self._memory_measurement_pids: List[int] = []
 
     def add_function(self, func: LocalFunction):
         self._functions.append(func)
+        if func.memory_measurement_pid is not None:
+            self._memory_measurement_pids.append(func.memory_measurement_pid)
 
     def add_input(self, func_input: dict):
         self._inputs.append(func_input)
 
     def set_storage(self, storage: Minio):
         self._storage = storage
-
-    def add_memory_measurements(self, pid: List[int]):
-        self._memory_measurements = pid
 
     def serialize(self, path: str):
         with open(path, "w") as out:
@@ -34,8 +35,8 @@ class Deployment:
                 "inputs": self._inputs,
             }
 
-            if self._memory_measurements is not None:
-                config["memory_measurements"] = self._memory_measurements
+            if self._memory_measurement_pids is not None:
+                config["memory_measurements"] = self._memory_measurement_pids
 
             out.write(serialize(config))
 
@@ -48,11 +49,59 @@ class Deployment:
                 deployment._inputs.append(input_cfg)
             for func in input_data["functions"]:
                 deployment._functions.append(LocalFunction.deserialize(func))
+            if "memory_measurements" in input_data:
+                deployment._memory_measurement_pids = input_data["memory_measurements"]
             deployment._storage = Minio.deserialize(
                 MinioConfig.deserialize(input_data["storage"]), cache_client
             )
             return deployment
 
-    def shutdown(self):
+    def shutdown(self, output_json: str):
+
+        if len(self._memory_measurement_pids) > 0:
+
+            # kill measuring processes
+            for proc in self._memory_measurement_pids:
+                subprocess.Popen(f"kill {proc}", shell=True)
+
+            # create dictionary with the measurements
+            measurements: dict = {}
+            precision_errors = 0
+            with open("measurements_temp_file.txt", "r") as file:
+                for line in file:
+                    if line == "precision not met\n":
+                        precision_errors += 1
+
+                    line_content = line.split()
+                    if len(line_content) == 0:
+                        continue
+                    if not line_content[0] in measurements:
+                        try:
+                            measurements[line_content[0]] = [int(line_content[1])]
+                        except ValueError:
+                            continue
+                    else:
+                        try:
+                            measurements[line_content[0]].append(int(line_content[1]))
+                        except ValueError:
+                            continue
+
+            for container in measurements:
+                measurements[container] = {
+                    "mean mem. usage": f"{mean(measurements[container])/1e6} MB",
+                    "max mem. usage": f"{max(measurements[container])/1e6} MB",
+                    "number of measurements": len(measurements[container]),
+                    "full profile (in bytes)": measurements[container],
+                }
+
+            # write to output_json file
+            with open(output_json, "w") as out:
+                if precision_errors > 0:
+                    measurements["precision_errors"] = precision_errors
+                json.dump(measurements, out, indent=6)
+
+            # remove the temporary file the measurements were written to
+            subprocess.Popen("rm measurements_temp_file.txt", shell=True)
+
         for func in self._functions:
             func.stop()

--- a/sebs/local/function.py
+++ b/sebs/local/function.py
@@ -1,6 +1,7 @@
 import concurrent.futures
 import docker
 import json
+from typing import Optional
 
 from sebs.faas.function import ExecutionResult, Function, FunctionConfig, Trigger
 
@@ -44,6 +45,7 @@ class LocalFunction(Function):
         benchmark: str,
         code_package_hash: str,
         config: FunctionConfig,
+        measurement_pid: Optional[int] = None,
     ):
         super().__init__(benchmark, name, code_package_hash, config)
         self._instance = docker_container
@@ -62,6 +64,12 @@ class LocalFunction(Function):
             raise RuntimeError(
                 f"Incorrect detection of IP address for container with id {self._instance_id}"
             )
+
+        self._measurement_pid = measurement_pid
+
+    @property
+    def memory_measurement_pid(self) -> Optional[int]:
+        return self._measurement_pid
 
     @staticmethod
     def typename() -> str:

--- a/sebs/local/local.py
+++ b/sebs/local/local.py
@@ -284,6 +284,6 @@ class Local(System):
             return
 
         # initialize an empty file for measurements to be written to
-        subprocess.Popen(
-            'touch measurements_temp_file.txt && echo "" > measurements_temp_file.txt', shell=True
-        )
+        from pathlib import Path
+
+        Path("measurements_temp_file.txt").touch()

--- a/sebs/local/measureMem.py
+++ b/sebs/local/measureMem.py
@@ -11,9 +11,9 @@ import time
 import argparse
 
 
-def measure(container_id: str, measure_interval: int) -> None:
+def measure(container_id: str, measure_interval: int, measurement_file: str) -> None:
 
-    f = open("measurements_temp_file.txt", "a")
+    f = open(measurement_file, "a")
 
     while True:
         time_start = time.perf_counter_ns()
@@ -38,7 +38,8 @@ def measure(container_id: str, measure_interval: int) -> None:
 """
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("-container_id", type=str)
-    parser.add_argument("-measure_interval", type=int)
+    parser.add_argument("--container-id", type=str)
+    parser.add_argument("--measurement-file", type=str)
+    parser.add_argument("--measure-interval", type=int)
     args, unknown = parser.parse_known_args()
-    measure(args.container_id, args.measure_interval)
+    measure(args.container_id, args.measure_interval, args.measurement_file)


### PR DESCRIPTION
We recently merged with the master a new feature of continuously measuring the memory consumption of a process.
This also fixes issues raised in #133 and #128.

- [x] Verify that not using memory measurement does not throw exceptions.
- [x] Verify that measurements are still generated correctly.
- [x] Replace `Popen` with Python libraries.
- [x] Use temporary files.
- [x] Update documentation