### PR TITLE
Support PyTorch benchmark for Python 3.8 and 3.9 on Lambda

### DIFF
--- a/benchmarks/400.inference/411.image-recognition/python/function.py
+++ b/benchmarks/400.inference/411.image-recognition/python/function.py
@@ -1,6 +1,15 @@
 
 import datetime, json, os, uuid
 
+# Extract zipped torch model - used in Python 3.8 and 3.9
+# The reason is that torch versions supported for these Python
+# versions are too large for Lambda packages.
+if os.path.exists('function/torch.zip'):
+    import zipfile, sys
+    # we cannot write to the read-only filesystem
+    zipfile.ZipFile('function/torch.zip').extractall('/tmp/')
+    sys.path.append(os.path.join(os.path.dirname(__file__), '/tmp/.python_packages/lib/site-packages'))
+
 from PIL import Image
 import torch
 from torchvision import transforms
@@ -13,7 +22,6 @@ SCRIPT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__)))
 class_idx = json.load(open(os.path.join(SCRIPT_DIR, "imagenet_class_index.json"), 'r'))
 idx2label = [class_idx[str(k)][1] for k in range(len(class_idx))]
 model = None
-
 
 def handler(event):
   

--- a/benchmarks/400.inference/411.image-recognition/python/package.sh
+++ b/benchmarks/400.inference/411.image-recognition/python/package.sh
@@ -15,11 +15,17 @@ find . -type d -name "bin" -not -path "*/torch/*" -exec rm -rf {} +
 find -name "*.so" -not -path "*/PIL/*" -not -path "*/Pillow.libs/*" | xargs strip
 find -name "*.so.*" -not -path "*/PIL/*" -not -path "*/Pillow.libs/*" | xargs strip
 
-rm -r pip > /dev/null
-rm -r pip-* > /dev/null
-rm -r wheel > /dev/null
-rm -r wheel-* > /dev/null
-rm easy_install.py > /dev/null
+rm -r pip >/dev/null
+rm -r pip-* >/dev/null
+rm -r wheel >/dev/null
+rm -r wheel-* >/dev/null
+rm easy_install.py >/dev/null
 find . -name \*.pyc -delete
 cd ${CUR_DIR}
 echo "Stripped size $(du -sh $1 | cut -f1)"
+
+if [[ "${PYTHON_VERSION}" == "3.8" ]] || [[ "${PYTHON_VERSION}" == "3.9" ]]; then
+	zip -qr torch.zip $1/torch
+	rm -rf $1/torch
+	echo "Torch-zipped size $(du -sh ${CUR_DIR} | cut -f1)"
+fi

--- a/dockerfiles/aws/python/Dockerfile.build
+++ b/dockerfiles/aws/python/Dockerfile.build
@@ -4,7 +4,7 @@ ARG VERSION
 ENV PYTHON_VERSION=${VERSION}
 
 # useradd, groupmod
-RUN yum install -y shadow-utils
+RUN yum install -y shadow-utils zip
 ENV GOSU_VERSION 1.14
 # https://github.com/tianon/gosu/releases/tag/1.14
 # key https://keys.openpgp.org/search?q=tianon%40debian.org

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -18,6 +18,9 @@
 For details on benchmark selection and their characterization, please refer to [our paper](#paper).
 
 > **Note**
+> Benchmark 411.image-recognition contains PyTorch which is often too large to fit into a code package. Up to Python 3.7, we can directly ship the dependencies. For Python 3.8 and 3.9, we used an additional zipping step that requires additional setup during the first run, making cold invocations slower. Warm invocations are not affected.
+
+> **Note**
 > Benchmarks whose number starts with the digit 0, such as `020.server-reply` are internal microbenchmarks used by specific experiments. They are not intended to be directly invoked by users.
 
 ## Workflow Applications


### PR DESCRIPTION
Torch versions needed in Python 3.8 and 3.9 are too large to fit in Lambda. To support them, we zip `torch` Python package and add unzipping to the cold start procedure. This is skipped on Python 3.7

In the future, we might need to use Docker images as a better solution for large packages.