### PR TITLE
Update AWS support for Node.js

### DIFF
--- a/config/systems.json
+++ b/config/systems.json
@@ -2,10 +2,17 @@
   "general": {
     "docker_repository": "spcleth/serverless-benchmarks"
   },
-  "local" : {
+  "local": {
     "experiments": {
-      "python": ["papi", "time", "disk-io", "memory"],
-      "nodejs": ["time"]
+      "python": [
+        "papi",
+        "time",
+        "disk-io",
+        "memory"
+      ],
+      "nodejs": [
+        "time"
+      ]
     },
     "languages": {
       "python": {
@@ -13,10 +20,15 @@
           "3.7": "python:3.7-slim",
           "3.8": "python:3.8-slim"
         },
-        "images": ["run", "build"],
+        "images": [
+          "run",
+          "build"
+        ],
         "username": "docker_user",
         "deployment": {
-          "files": ["storage.py"],
+          "files": [
+            "storage.py"
+          ],
           "packages": []
         }
       },
@@ -25,16 +37,21 @@
           "12": "node:12-slim",
           "14": "node:14-slim"
         },
-        "images": ["run", "build"],
+        "images": [
+          "run",
+          "build"
+        ],
         "username": "docker_user",
         "deployment": {
-          "files": ["storage.js"],
+          "files": [
+            "storage.js"
+          ],
           "packages": []
         }
       }
     }
   },
-  "aws": { 
+  "aws": {
     "languages": {
       "python": {
         "base_images": {
@@ -42,22 +59,39 @@
           "3.8": "amazon/aws-lambda-python:3.8",
           "3.7": "amazon/aws-lambda-python:3.7"
         },
-        "versions": ["3.7", "3.8", "3.9"],
-        "images": ["build"],
+        "versions": [
+          "3.7",
+          "3.8",
+          "3.9"
+        ],
+        "images": [
+          "build"
+        ],
         "deployment": {
-          "files": [ "handler.py", "storage.py"],
+          "files": [
+            "handler.py",
+            "storage.py"
+          ],
           "packages": []
         }
       },
       "nodejs": {
         "base_images": {
-          "14.x" : "amazon/aws-lambda-nodejs:14",
-          "12.x" : "amazon/aws-lambda-nodejs:12"
+          "14": "amazon/aws-lambda-nodejs:14",
+          "12": "amazon/aws-lambda-nodejs:12"
         },
-        "versions": ["12.x", "14.x"],
-        "images": ["build"],
+        "versions": [
+          "12",
+          "14"
+        ],
+        "images": [
+          "build"
+        ],
         "deployment": {
-          "files": [ "handler.js", "storage.js"],
+          "files": [
+            "handler.js",
+            "storage.js"
+          ],
           "packages": {
             "uuid": "3.4.0"
           }
@@ -73,22 +107,34 @@
           "3.8": "mcr.microsoft.com/azure-functions/python:3.0-python3.8",
           "3.9": "mcr.microsoft.com/azure-functions/python:3.0-python3.9"
         },
-        "images": ["build"],
+        "images": [
+          "build"
+        ],
         "username": "docker_user",
         "deployment": {
-          "files": [ "handler.py", "storage.py"],
-          "packages": ["azure-storage-blob"]
+          "files": [
+            "handler.py",
+            "storage.py"
+          ],
+          "packages": [
+            "azure-storage-blob"
+          ]
         }
       },
       "nodejs": {
         "base_images": {
-          "14" : "mcr.microsoft.com/azure-functions/node:3.0-node14",
-          "12" : "mcr.microsoft.com/azure-functions/node:3.0-node12"
+          "14": "mcr.microsoft.com/azure-functions/node:3.0-node14",
+          "12": "mcr.microsoft.com/azure-functions/node:3.0-node12"
         },
-        "images": ["build"],
+        "images": [
+          "build"
+        ],
         "username": "docker_user",
         "deployment": {
-          "files": [ "handler.js", "storage.js"],
+          "files": [
+            "handler.js",
+            "storage.js"
+          ],
           "packages": {
             "@azure/storage-blob": "^12.0.0",
             "uuid": "3.4.0"
@@ -108,23 +154,35 @@
         "base_images": {
           "3.7": "gcr.io/google-appengine/python"
         },
-        "images": ["build"],
+        "images": [
+          "build"
+        ],
         "username": "docker_user",
         "deployment": {
-          "files": [ "handler.py", "storage.py"],
-          "packages": ["google-cloud-storage"]
+          "files": [
+            "handler.py",
+            "storage.py"
+          ],
+          "packages": [
+            "google-cloud-storage"
+          ]
         }
       },
       "nodejs": {
         "base_images": {
-          "10" : "gcr.io/google-appengine/nodejs",
-          "12" : "gcr.io/google-appengine/nodejs",
-          "14" : "gcr.io/google-appengine/nodejs"
+          "10": "gcr.io/google-appengine/nodejs",
+          "12": "gcr.io/google-appengine/nodejs",
+          "14": "gcr.io/google-appengine/nodejs"
         },
-        "images": ["build"],
+        "images": [
+          "build"
+        ],
         "username": "docker_user",
         "deployment": {
-          "files": [ "handler.js", "storage.js"],
+          "files": [
+            "handler.js",
+            "storage.js"
+          ],
           "packages": {
             "@google-cloud/storage": "^4.0.0",
             "uuid": "3.4.0"
@@ -140,10 +198,16 @@
           "3.7": "openwhisk/action-python-v3.7",
           "3.9": "openwhisk/action-python-v3.9"
         },
-        "images": ["function"],
+        "images": [
+          "function"
+        ],
         "username": "docker_user",
         "deployment": {
-          "files": [ "__main__.py", "storage.py", "setup.py"],
+          "files": [
+            "__main__.py",
+            "storage.py",
+            "setup.py"
+          ],
           "packages": {
             "minio": "^5.0.10"
           }
@@ -151,13 +215,18 @@
       },
       "nodejs": {
         "base_images": {
-          "10" : "openwhisk/action-nodejs-v10",
-          "12" : "openwhisk/action-nodejs-v12"
+          "10": "openwhisk/action-nodejs-v10",
+          "12": "openwhisk/action-nodejs-v12"
         },
-        "images": ["function"],
+        "images": [
+          "function"
+        ],
         "username": "docker_user",
         "deployment": {
-          "files": [ "index.js", "storage.js"],
+          "files": [
+            "index.js",
+            "storage.js"
+          ],
           "packages": {
             "minio": "^7.0.16"
           }

--- a/config/systems.json
+++ b/config/systems.json
@@ -77,11 +77,9 @@
       },
       "nodejs": {
         "base_images": {
-          "14": "amazon/aws-lambda-nodejs:14",
-          "12": "amazon/aws-lambda-nodejs:12"
+          "14": "amazon/aws-lambda-nodejs:14"
         },
         "versions": [
-          "12",
           "14"
         ],
         "images": [

--- a/install.py
+++ b/install.py
@@ -36,7 +36,7 @@ else:
     print("Using existing Python virtualenv at {}".format(env_dir))
 
 print("Install Python dependencies with pip")
-execute(". {}/bin/activate && pip3 install -r requirements.txt --upgrade && pip3 install typing-extensions --upgrade".format(env_dir))
+execute(". {}/bin/activate && pip3 install -r requirements.txt --upgrade".format(env_dir))
 
 if args.aws:
     print("Install Python dependencies for AWS")
@@ -68,6 +68,10 @@ if args.local:
     execute(". {}/bin/activate && pip3 install -r requirements.local.txt".format(env_dir))
     print("Initialize Docker image for local storage.")
     execute("docker pull minio/minio:latest")
+
+# One of the installed dependencies causes a downgrade, which in turns breaks static typing.
+print("Update typing-extensions (resolving bug with mypy)")
+execute(". {}/bin/activate && pip3 install typing-extensions --upgrade".format(env_dir))
 
 print("Download benchmarks data")
 try:

--- a/sebs/aws/aws.py
+++ b/sebs/aws/aws.py
@@ -156,6 +156,14 @@ class AWS(System):
 
         return os.path.join(directory, "{}.zip".format(benchmark)), bytes_size
 
+    def _map_language_runtime(self, language: str, runtime: str):
+
+        # AWS uses different naming scheme for Node.js versions
+        # For example, it's 12.x instead of 12.
+        if language == "nodejs":
+            return f"{runtime}.x"
+        return runtime
+
     def create_function(self, code_package: Benchmark, func_name: str) -> "LambdaFunction":
 
         package = code_package.code_location
@@ -210,7 +218,9 @@ class AWS(System):
                 code_config = {"S3Bucket": code_bucket, "S3Key": code_package_name}
             ret = self.client.create_function(
                 FunctionName=func_name,
-                Runtime="{}{}".format(language, language_runtime),
+                Runtime="{}{}".format(
+                    language, self._map_language_runtime(language, language_runtime)
+                ),
                 Handler="handler.handler",
                 Role=self.config.resources.lambda_role(self.session),
                 MemorySize=memory,


### PR DESCRIPTION
This PR updates our handling of Node.js functions on AWS. First, it simplifies the management of version numbers by automatically mapping from the generic version number `NUMBER` to AWS-specific `NUMBER.x`.

Then, it removes support for Node.js 12 as AWS has deprecated it and is no longer available.