### PR TITLE
Improve handling of cloud credentials and account identification

### DIFF
--- a/sebs/aws/config.py
+++ b/sebs/aws/config.py
@@ -13,14 +13,16 @@ from sebs.utils import LoggingHandlers
 
 
 class AWSCredentials(Credentials):
-
-    _access_key: str
-    _secret_key: str
-
     def __init__(self, access_key: str, secret_key: str):
-        super().__init__()
         self._access_key = access_key
         self._secret_key = secret_key
+
+        client = boto3.client(
+            "sts", aws_access_key_id=self.access_key, aws_secret_access_key=self.secret_key
+        )
+        account_id = client.get_caller_identity()["Account"]
+
+        super().__init__(account_id)
 
     @staticmethod
     def typename() -> str:
@@ -35,7 +37,7 @@ class AWSCredentials(Credentials):
         return self._secret_key
 
     @staticmethod
-    def initialize(dct: dict) -> Credentials:
+    def initialize(dct: dict) -> "AWSCredentials":
         return AWSCredentials(dct["access_key"], dct["secret_key"])
 
     @staticmethod
@@ -45,36 +47,40 @@ class AWSCredentials(Credentials):
         # needs 3.7+  to support annotations
         cached_config = cache.get_config("aws")
         ret: AWSCredentials
+        account_id: Optional[str] = None
+
         # Load cached values
         if cached_config and "credentials" in cached_config:
-            ret = cast(AWSCredentials, AWSCredentials.initialize(cached_config["credentials"]))
-            ret.logging_handlers = handlers
-            ret.logging.info("Using cached credentials for AWS")
+            account_id = cached_config["credentials"]["account_id"]
+
+        # Check for new config
+        if "credentials" in config:
+            ret = AWSCredentials.initialize(config["credentials"])
+        elif "AWS_ACCESS_KEY_ID" in os.environ:
+            ret = AWSCredentials(
+                os.environ["AWS_ACCESS_KEY_ID"], os.environ["AWS_SECRET_ACCESS_KEY"]
+            )
         else:
-            # Check for new config
-            if "credentials" in config:
-                ret = cast(AWSCredentials, AWSCredentials.initialize(config["credentials"]))
-            elif "AWS_ACCESS_KEY_ID" in os.environ:
-                ret = AWSCredentials(
-                    os.environ["AWS_ACCESS_KEY_ID"], os.environ["AWS_SECRET_ACCESS_KEY"]
-                )
-            else:
-                raise RuntimeError(
-                    "AWS login credentials are missing! Please set "
-                    "up environmental variables AWS_ACCESS_KEY_ID and "
-                    "AWS_SECRET_ACCESS_KEY"
-                )
-            ret.logging.info("No cached credentials for AWS found, initialize!")
-            ret.logging_handlers = handlers
+            raise RuntimeError(
+                "AWS login credentials are missing! Please set "
+                "up environmental variables AWS_ACCESS_KEY_ID and "
+                "AWS_SECRET_ACCESS_KEY"
+            )
+
+        if account_id is not None and account_id != ret.account_id:
+            ret.logging.error(
+                f"The account id {ret.account_id} from provided credentials is different "
+                f"from the account id {account_id} found in the cache! Please change "
+                " your cache directory or create a new one!"
+            )
+            raise RuntimeError(
+                f"AWS login credentials do not match the acccount {account_id} in cache!"
+            )
+        ret.logging_handlers = handlers
         return ret
 
     def update_cache(self, cache: Cache):
-        cache.update_config(val=self.access_key, keys=["aws", "credentials", "access_key"])
-        cache.update_config(val=self.secret_key, keys=["aws", "credentials", "secret_key"])
-
-    def serialize(self) -> dict:
-        out = {"access_key": self.access_key, "secret_key": self.secret_key}
-        return out
+        cache.update_config(val=self.account_id, keys=["aws", "credentials", "account_id"])
 
 
 class AWSResources(Resources):

--- a/sebs/aws/config.py
+++ b/sebs/aws/config.py
@@ -38,12 +38,7 @@ class AWSCredentials(Credentials):
 
     @property
     def account_id(self) -> str:
-        assert self._account_id is not None
         return self._account_id
-
-    @property
-    def has_account_id(self) -> bool:
-        return self._account_id is not None
 
     @staticmethod
     def initialize(dct: dict) -> "AWSCredentials":

--- a/sebs/aws/config.py
+++ b/sebs/aws/config.py
@@ -14,15 +14,15 @@ from sebs.utils import LoggingHandlers
 
 class AWSCredentials(Credentials):
     def __init__(self, access_key: str, secret_key: str):
+        super().__init__()
+
         self._access_key = access_key
         self._secret_key = secret_key
 
         client = boto3.client(
             "sts", aws_access_key_id=self.access_key, aws_secret_access_key=self.secret_key
         )
-        account_id = client.get_caller_identity()["Account"]
-
-        super().__init__(account_id)
+        self._account_id = client.get_caller_identity()["Account"]
 
     @staticmethod
     def typename() -> str:
@@ -35,6 +35,15 @@ class AWSCredentials(Credentials):
     @property
     def secret_key(self) -> str:
         return self._secret_key
+
+    @property
+    def account_id(self) -> str:
+        assert self._account_id is not None
+        return self._account_id
+
+    @property
+    def has_account_id(self) -> bool:
+        return self._account_id is not None
 
     @staticmethod
     def initialize(dct: dict) -> "AWSCredentials":
@@ -81,6 +90,10 @@ class AWSCredentials(Credentials):
 
     def update_cache(self, cache: Cache):
         cache.update_config(val=self.account_id, keys=["aws", "credentials", "account_id"])
+
+    def serialize(self) -> dict:
+        out = {"account_id": self._account_id}
+        return out
 
 
 class AWSResources(Resources):

--- a/sebs/aws/config.py
+++ b/sebs/aws/config.py
@@ -71,7 +71,7 @@ class AWSCredentials(Credentials):
             ret.logging.error(
                 f"The account id {ret.account_id} from provided credentials is different "
                 f"from the account id {account_id} found in the cache! Please change "
-                " your cache directory or create a new one!"
+                "your cache directory or create a new one!"
             )
             raise RuntimeError(
                 f"AWS login credentials do not match the acccount {account_id} in cache!"

--- a/sebs/azure/azure.py
+++ b/sebs/azure/azure.py
@@ -61,11 +61,19 @@ class Azure(System):
 
     def initialize(self, config: Dict[str, str] = {}):
         self.cli_instance = AzureCLI(self.system_config, self.docker_client)
-        self.cli_instance.login(
+        output = self.cli_instance.login(
             appId=self.config.credentials.appId,
             tenant=self.config.credentials.tenant,
             password=self.config.credentials.password,
         )
+
+        subscriptions = json.loads(output)
+        if len(subscriptions) == 0:
+            raise RuntimeError("Didn't find any valid subscription on Azure!")
+        if len(subscriptions) > 1:
+            raise RuntimeError("Found more than one valid subscription on Azure - not supported!")
+
+        self.config.credentials.subscription_id = subscriptions[0]["id"]
 
     def shutdown(self):
         if self.cli_instance:

--- a/sebs/azure/cli.py
+++ b/sebs/azure/cli.py
@@ -67,8 +67,8 @@ class AzureCLI:
         Run azure login command on Docker instance.
     """
 
-    def login(self, appId: str, tenant: str, password: str):
-        self.execute(
+    def login(self, appId: str, tenant: str, password: str) -> bytes:
+        result = self.execute(
             "az login -u {0} --service-principal --tenant {1} -p {2}".format(
                 appId,
                 tenant,
@@ -76,6 +76,7 @@ class AzureCLI:
             )
         )
         logging.info("Azure login succesful")
+        return result
 
     def upload_package(self, directory: str, dest: str):
         handle = io.BytesIO()

--- a/sebs/azure/config.py
+++ b/sebs/azure/config.py
@@ -17,11 +17,15 @@ class AzureCredentials(Credentials):
     _tenant: str
     _password: str
 
-    def __init__(self, appId: str, tenant: str, password: str):
+    def __init__(
+        self, appId: str, tenant: str, password: str, cached_subscription_id: Optional[str] = None
+    ):
         super().__init__()
         self._appId = appId
         self._tenant = tenant
         self._password = password
+        self._subscription_id: Optional[str] = None
+        self._cached_subscription_id = cached_subscription_id
 
     @property
     def appId(self) -> str:
@@ -35,50 +39,71 @@ class AzureCredentials(Credentials):
     def password(self) -> str:
         return self._password
 
+    @property
+    def subscription_id(self) -> str:
+        assert self._subscription_id is not None
+        return self._subscription_id
+
+    @subscription_id.setter
+    def subscription_id(self, subscription_id: str):
+
+        if (
+            self._cached_subscription_id is not None
+            and subscription_id != self._cached_subscription_id
+        ):
+            self.logging.error(
+                f"The subscription id {subscription_id} from provided "
+                f"credentials is different from the subscription id "
+                f"{self._cached_subscription_id} found in the cache! "
+                "Please change your cache directory or create a new one!"
+            )
+            raise RuntimeError(
+                f"Azure login credentials do not match the subscription "
+                f"{self._cached_subscription_id} in cache!"
+            )
+
+        self._subscription_id = subscription_id
+
+    @property
+    def has_subscription_id(self) -> bool:
+        return self._subscription_id is not None
+
     @staticmethod
-    def initialize(dct: dict) -> Credentials:
-        return AzureCredentials(dct["appId"], dct["tenant"], dct["password"])
+    def initialize(dct: dict, subscription_id: Optional[str]) -> "AzureCredentials":
+        return AzureCredentials(dct["appId"], dct["tenant"], dct["password"], subscription_id)
 
     @staticmethod
     def deserialize(config: dict, cache: Cache, handlers: LoggingHandlers) -> Credentials:
 
-        # FIXME: update return types of both functions to avoid cast
-        # needs 3.7+  to support annotations
         cached_config = cache.get_config("azure")
         ret: AzureCredentials
+        old_subscription_id: Optional[str] = None
         # Load cached values
         if cached_config and "credentials" in cached_config:
-            ret = cast(
-                AzureCredentials,
-                AzureCredentials.initialize(cached_config["credentials"]),
+            old_subscription_id = cached_config["credentials"]["subscription_id"]
+
+        # Check for new config
+        if "credentials" in config:
+            ret = AzureCredentials.initialize(config["credentials"], old_subscription_id)
+        elif "AZURE_SECRET_APPLICATION_ID" in os.environ:
+            ret = AzureCredentials(
+                os.environ["AZURE_SECRET_APPLICATION_ID"],
+                os.environ["AZURE_SECRET_TENANT"],
+                os.environ["AZURE_SECRET_PASSWORD"],
+                old_subscription_id,
             )
-            ret.logging_handlers = handlers
-            ret.logging.info("Using cached credentials for Azure")
         else:
-            # Check for new config
-            if "credentials" in config:
-                ret = cast(
-                    AzureCredentials,
-                    AzureCredentials.initialize(config["credentials"]),
-                )
-            elif "AZURE_SECRET_APPLICATION_ID" in os.environ:
-                ret = AzureCredentials(
-                    os.environ["AZURE_SECRET_APPLICATION_ID"],
-                    os.environ["AZURE_SECRET_TENANT"],
-                    os.environ["AZURE_SECRET_PASSWORD"],
-                )
-            else:
-                raise RuntimeError(
-                    "Azure login credentials are missing! Please set "
-                    "up environmental variables AZURE_SECRET_APPLICATION_ID and "
-                    "AZURE_SECRET_TENANT and AZURE_SECRET_PASSWORD"
-                )
-            ret.logging_handlers = handlers
-            ret.logging.info("No cached credentials for Azure found, initialize!")
+            raise RuntimeError(
+                "Azure login credentials are missing! Please set "
+                "up environmental variables AZURE_SECRET_APPLICATION_ID and "
+                "AZURE_SECRET_TENANT and AZURE_SECRET_PASSWORD"
+            )
+        ret.logging_handlers = handlers
+
         return ret
 
     def serialize(self) -> dict:
-        out = {"appId": self.appId, "tenant": self.tenant, "password": self.password}
+        out = {"subscription_id": self.subscription_id}
         return out
 
     def update_cache(self, cache_client: Cache):

--- a/sebs/faas/config.py
+++ b/sebs/faas/config.py
@@ -1,7 +1,7 @@
 from abc import ABC
 from abc import abstractmethod
 
-from sebs.cache import Cache
+from sebs.cache import Cache, Optional
 from sebs.utils import has_platform, LoggingBase, LoggingHandlers
 
 # FIXME: Replace type hints for static generators after migration to 3.7
@@ -20,8 +20,18 @@ from sebs.utils import has_platform, LoggingBase, LoggingHandlers
 
 
 class Credentials(ABC, LoggingBase):
-    def __init__(self):
+    def __init__(self, account_id: Optional[str] = None):
         super().__init__()
+        self._account_id = account_id
+
+    @property
+    def account_id(self) -> str:
+        assert self._account_id is not None
+        return self._account_id
+
+    @property
+    def has_account_id(self) -> bool:
+        return self._account_id is not None
 
     """
         Create credentials instance from user config and cached values.
@@ -36,9 +46,9 @@ class Credentials(ABC, LoggingBase):
         Serialize to JSON for storage in cache.
     """
 
-    @abstractmethod
     def serialize(self) -> dict:
-        pass
+        out = {"account_id": self._account_id}
+        return out
 
 
 """

--- a/sebs/faas/config.py
+++ b/sebs/faas/config.py
@@ -1,7 +1,7 @@
 from abc import ABC
 from abc import abstractmethod
 
-from sebs.cache import Cache, Optional
+from sebs.cache import Cache
 from sebs.utils import has_platform, LoggingBase, LoggingHandlers
 
 # FIXME: Replace type hints for static generators after migration to 3.7
@@ -20,18 +20,8 @@ from sebs.utils import has_platform, LoggingBase, LoggingHandlers
 
 
 class Credentials(ABC, LoggingBase):
-    def __init__(self, account_id: Optional[str] = None):
+    def __init__(self):
         super().__init__()
-        self._account_id = account_id
-
-    @property
-    def account_id(self) -> str:
-        assert self._account_id is not None
-        return self._account_id
-
-    @property
-    def has_account_id(self) -> bool:
-        return self._account_id is not None
 
     """
         Create credentials instance from user config and cached values.
@@ -46,9 +36,9 @@ class Credentials(ABC, LoggingBase):
         Serialize to JSON for storage in cache.
     """
 
+    @abstractmethod
     def serialize(self) -> dict:
-        out = {"account_id": self._account_id}
-        return out
+        pass
 
 
 """

--- a/sebs/gcp/config.py
+++ b/sebs/gcp/config.py
@@ -1,5 +1,6 @@
+import json
 import os
-from typing import cast, List, Tuple
+from typing import cast, List, Optional, Tuple
 
 from sebs.cache import Cache
 from sebs.faas.config import Config, Credentials, Resources
@@ -21,63 +22,72 @@ from sebs.utils import LoggingHandlers
 
 
 class GCPCredentials(Credentials):
-    _gcp_credentials: str
-
     def __init__(self, gcp_credentials: str):
-        super().__init__()
         self._gcp_credentials = gcp_credentials
+
+        gcp_data = json.load(open(gcp_credentials, "r"))
+        client_id = gcp_data["client_id"]
+        self._project_id = gcp_data["project_id"]
+
+        super().__init__(client_id)
 
     @property
     def gcp_credentials(self) -> str:
         return self._gcp_credentials
 
+    @property
+    def project_name(self) -> str:
+        return self._project_id
+
     @staticmethod
-    def initialize(gcp_credentials: str) -> Credentials:
+    def initialize(gcp_credentials: str) -> "GCPCredentials":
         return GCPCredentials(gcp_credentials)
 
     @staticmethod
     def deserialize(config: dict, cache: Cache, handlers: LoggingHandlers) -> Credentials:
+
         cached_config = cache.get_config("gcp")
         ret: GCPCredentials
-        # Load cached values but only if they are non-empty
-        if (
-            cached_config
-            and "credentials" in cached_config
-            and cached_config["credentials"]["keys_json"]
-        ):
-            ret = cast(
-                GCPCredentials,
-                GCPCredentials.initialize(cached_config["credentials"]["keys_json"]),
-            )
+        project_id: Optional[str] = None
+        client_id: Optional[str] = None
+
+        # Load cached values
+        if cached_config and "credentials" in cached_config:
+            client_id = cached_config["credentials"]["account_id"]
+            project_id = cached_config["credentials"]["project_id"]
+
+        # Check for new config
+        if "credentials" in config and config["credentials"]:
+            ret = GCPCredentials.initialize(config["credentials"])
             os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = ret.gcp_credentials
-            ret.logging_handlers = handlers
-            ret.logging.info("Using cached credentials for GCP")
+        # Look for default GCP credentials
+        elif "GOOGLE_APPLICATION_CREDENTIALS" in os.environ:
+            ret = GCPCredentials(os.environ["GOOGLE_APPLICATION_CREDENTIALS"])
+        # Look for our environment variables
+        elif "GCP_SECRET_APPLICATION_CREDENTIALS" in os.environ:
+            ret = GCPCredentials(os.environ["GCP_SECRET_APPLICATION_CREDENTIALS"])
+            os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = ret.gcp_credentials
         else:
-            # Check for new config
-            if "credentials" in config and config["credentials"]:
-                ret = cast(GCPCredentials, GCPCredentials.initialize(config["credentials"]))
-                os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = ret.gcp_credentials
-            # Look for default GCP credentials
-            elif "GOOGLE_APPLICATION_CREDENTIALS" in os.environ:
-                ret = GCPCredentials(os.environ["GOOGLE_APPLICATION_CREDENTIALS"])
-                cache.update_config(
-                    val=ret.gcp_credentials, keys=["gcp", "credentials", "keys_json"]
-                )
-            # Look for our environment variables
-            elif "GCP_SECRET_APPLICATION_CREDENTIALS" in os.environ:
-                ret = GCPCredentials(os.environ["GCP_SECRET_APPLICATION_CREDENTIALS"])
-                cache.update_config(
-                    val=ret.gcp_credentials, keys=["gcp", "credentials", "keys_json"]
-                )
-                os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = ret.gcp_credentials
-            else:
-                raise RuntimeError(
-                    "GCP login credentials are missing! Please set the path to .json "
-                    "with cloud credentials in config or in the GCP_SECRET_APPLICATION_CREDENTIALS "
-                    "environmental variable"
-                )
-            ret.logging_handlers = handlers
-            ret.logging.info("No cached credentials for GCP found, initialize!")
+            raise RuntimeError(
+                "GCP login credentials are missing! Please set the path to .json "
+                "with cloud credentials in config or in the GCP_SECRET_APPLICATION_CREDENTIALS "
+                "environmental variable"
+            )
+        ret.logging_handlers = handlers
+
+        if project_id is not None and (
+            project_id != ret._project_id or client_id != ret.account_id
+        ):
+            ret.logging.error(
+                f"The account and project pair ({ret.account_id}, {ret._project_id}) from provided "
+                f"credentials is different from the pair ({client_id}, {project_id}) in the cache! "
+                "Please change your cache directory or create a new one!"
+            )
+            raise RuntimeError(
+                f"GCP login credentials do not match the acccount {client_id} and "
+                f"project {project_id} in cache!"
+            )
+
         return ret
 
     """
@@ -85,11 +95,12 @@ class GCPCredentials(Credentials):
     """
 
     def serialize(self) -> dict:
-        out = {"keys_json": self.gcp_credentials}
+        out = {**super().serialize(), "project_id": self._project_id}
         return out
 
     def update_cache(self, cache: Cache):
-        cache.update_config(val=self.gcp_credentials, keys=["gcp", "credentials", "keys_json"])
+        cache.update_config(val=self.account_id, keys=["gcp", "credentials", "account_id"])
+        cache.update_config(val=self._project_id, keys=["gcp", "credentials", "project_id"])
 
 
 """
@@ -155,7 +166,7 @@ class GCPConfig(Config):
 
     @property
     def project_name(self) -> str:
-        return self._project_name
+        return self.credentials.project_name
 
     @property
     def credentials(self) -> GCPCredentials:
@@ -172,32 +183,16 @@ class GCPConfig(Config):
         resources = cast(GCPResources, GCPResources.deserialize(config, cache, handlers))
         config_obj = GCPConfig(credentials, resources)
         config_obj.logging_handlers = handlers
+
         if cached_config:
             config_obj.logging.info("Loading cached config for GCP")
             GCPConfig.initialize(config_obj, cached_config)
         else:
             config_obj.logging.info("Using user-provided config for GCP")
-
-            # User didn't provide the project name
-            if "project_name" not in config or not config["project_name"]:
-                if "GCP_PROJECT_NAME" in os.environ:
-                    GCPConfig.initialize(
-                        config_obj, {**config, "project_name": os.environ["GCP_PROJECT_NAME"]}
-                    )
-                else:
-                    raise RuntimeError(
-                        "Google Cloud Platform: project name is missing! "
-                        "Please provide it in configuration or through the "
-                        "GCP_PROJECT_NAME environment variable!"
-                    )
-            else:
-                GCPConfig.initialize(config_obj, config)
+            GCPConfig.initialize(config_obj, config)
 
         # mypy makes a mistake here
-        updated_keys: List[Tuple[str, Tuple[str]]] = [
-            ["region", ["gcp", "region"]],  # type: ignore
-            ["project_name", ["gcp", "project_name"]],  # type: ignore
-        ]
+        updated_keys: List[Tuple[str, Tuple[str]]] = [["region", ["gcp", "region"]]]  # type: ignore
         # for each attribute here, check if its version is different than the one provided by
         # user; if yes, then update the value
         for config_key, keys in updated_keys:
@@ -217,13 +212,11 @@ class GCPConfig(Config):
     @staticmethod
     def initialize(cfg: Config, dct: dict):
         config = cast(GCPConfig, cfg)
-        config._project_name = dct["project_name"]
         config._region = dct["region"]
 
     def serialize(self) -> dict:
         out = {
             "name": "gcp",
-            "project_name": self._project_name,
             "region": self._region,
             "credentials": self._credentials.serialize(),
             "resources": self._resources.serialize(),
@@ -231,7 +224,6 @@ class GCPConfig(Config):
         return out
 
     def update_cache(self, cache: Cache):
-        cache.update_config(val=self.project_name, keys=["gcp", "project_name"])
         cache.update_config(val=self.region, keys=["gcp", "region"])
         self.credentials.update_cache(cache)
         self.resources.update_cache(cache)


### PR DESCRIPTION
This PR fixes #97 - we no longer store any credentials in SeBS. Instead, we store non-sensitive account identifiers to connect cache & results with a specific account or cloud subscription.

Many thanks to @nurSaadat for raising the importance of this issue!