### PR TITLE
Implement a single-bucket design.

### DIFF
--- a/benchmarks/100.webapps/110.dynamic-html/input.py
+++ b/benchmarks/100.webapps/110.dynamic-html/input.py
@@ -8,7 +8,7 @@ size_generators = {
 def buckets_count():
     return (0, 0)
 
-def generate_input(data_dir, size, input_buckets, output_buckets, upload_func):
+def generate_input(data_dir, size, benchmarks_bucket, input_paths, output_paths, upload_func):
     input_config = {'username': 'testname'} 
     input_config['random_len'] = size_generators[size]
     return input_config

--- a/benchmarks/100.webapps/120.uploader/input.py
+++ b/benchmarks/100.webapps/120.uploader/input.py
@@ -11,8 +11,9 @@ url_generators = {
 def buckets_count():
     return (0, 1)
 
-def generate_input(data_dir, size, input_buckets, output_buckets, upload_func):
+def generate_input(data_dir, size, benchmarks_bucket, input_buckets, output_buckets, upload_func):
     input_config = {'object': {}, 'bucket': {}}
     input_config['object']['url'] = url_generators[size]
+    input_config['bucket']['bucket'] = benchmarks_bucket
     input_config['bucket']['output'] = output_buckets[0]
     return input_config

--- a/benchmarks/100.webapps/120.uploader/nodejs/function.js
+++ b/benchmarks/100.webapps/120.uploader/nodejs/function.js
@@ -15,7 +15,8 @@ function streamToPromise(stream) {
 }
 
 exports.handler = async function(event) {
-  let output_bucket = event.bucket.output
+  let bucket = event.bucket.bucket
+  let output_prefix = event.bucket.output
   let url = event.object.url
   let upload_key = path.basename(url)
   let download_path = path.join('/tmp', upload_key)
@@ -26,10 +27,10 @@ exports.handler = async function(event) {
   var keyName;
   let upload = promise.then(
     async () => {
-      [keyName, promise] = storage_handler.upload(output_bucket, upload_key, download_path);
+      [keyName, promise] = storage_handler.upload(bucket, path.join(output_prefix, upload_key), download_path);
       await promise;
     }
   );
   await upload;
-  return {bucket: output_bucket, url: url, key: keyName}
+  return {bucket: bucket, url: url, key: keyName}
 };

--- a/benchmarks/100.webapps/120.uploader/python/function.py
+++ b/benchmarks/100.webapps/120.uploader/python/function.py
@@ -11,7 +11,8 @@ client = storage.storage.get_instance()
 
 def handler(event):
   
-    output_bucket = event.get('bucket').get('output')
+    bucket = event.get('bucket').get('bucket')
+    output_prefix = event.get('bucket').get('output')
     url = event.get('object').get('url')
     name = os.path.basename(url)
     download_path = '/tmp/{}'.format(name)
@@ -22,14 +23,14 @@ def handler(event):
     process_end = datetime.datetime.now()
 
     upload_begin = datetime.datetime.now()
-    key_name = client.upload(output_bucket, name, download_path)
+    key_name = client.upload(bucket, os.path.join(output_prefix, name), download_path)
     upload_end = datetime.datetime.now()
 
     process_time = (process_end - process_begin) / datetime.timedelta(microseconds=1)
     upload_time = (upload_end - upload_begin) / datetime.timedelta(microseconds=1)
     return {
             'result': {
-                'bucket': output_bucket,
+                'bucket': bucket,
                 'url': url,
                 'key': key_name
             },

--- a/benchmarks/200.multimedia/210.thumbnailer/input.py
+++ b/benchmarks/200.multimedia/210.thumbnailer/input.py
@@ -12,15 +12,18 @@ def buckets_count():
     :param output_buckets:
     :param upload_func: upload function taking three params(bucket_idx, key, filepath)
 '''
-def generate_input(data_dir, size, input_buckets, output_buckets, upload_func):
+def generate_input(data_dir, size, benchmarks_bucket, input_paths, output_paths, upload_func):
+
     for file in glob.glob(os.path.join(data_dir, '*.jpg')):
         img = os.path.relpath(file, data_dir)
         upload_func(0, img, file)
+
     #TODO: multiple datasets
     input_config = {'object': {}, 'bucket': {}}
     input_config['object']['key'] = img
     input_config['object']['width'] = 200
     input_config['object']['height'] = 200
-    input_config['bucket']['input'] = input_buckets[0]
-    input_config['bucket']['output'] = output_buckets[0]
+    input_config['bucket']['bucket'] = benchmarks_bucket
+    input_config['bucket']['input'] = input_paths[0]
+    input_config['bucket']['output'] = output_paths[0]
     return input_config

--- a/benchmarks/200.multimedia/210.thumbnailer/nodejs/function.js
+++ b/benchmarks/200.multimedia/210.thumbnailer/nodejs/function.js
@@ -5,8 +5,10 @@ const sharp = require('sharp'),
 let storage_handler = new storage.storage();
 
 exports.handler = async function(event) {
-  input_bucket = event.bucket.input
-  output_bucket = event.bucket.output
+
+  bucket = event.bucket.bucket
+  input_prefix = event.bucket.input
+  output_prefix = event.bucket.output
   let key = event.object.key
   width = event.object.width
   height = event.object.height
@@ -14,13 +16,13 @@ exports.handler = async function(event) {
   let upload_key = key.substr(0, pos < 0 ? key.length : pos) + '.png';
 
   const sharp_resizer = sharp().resize(width, height).png();
-  let read_promise = storage_handler.downloadStream(input_bucket, key);
-  let [writeStream, promise, uploadName] = storage_handler.uploadStream(output_bucket, upload_key);
+  let read_promise = storage_handler.downloadStream(bucket, path.join(input_prefix, key));
+  let [writeStream, promise, uploadName] = storage_handler.uploadStream(bucket, path.join(output_prefix, upload_key));
   read_promise.then(
     (input_stream) => {
       input_stream.pipe(sharp_resizer).pipe(writeStream);
     }
   );
   await promise;
-  return {bucket: output_bucket, key: uploadName}
+  return {bucket: output_prefix, key: uploadName}
 };

--- a/benchmarks/200.multimedia/210.thumbnailer/python/function.py
+++ b/benchmarks/200.multimedia/210.thumbnailer/python/function.py
@@ -27,8 +27,9 @@ def resize_image(image_bytes, w, h):
 
 def handler(event):
   
-    input_bucket = event.get('bucket').get('input')
-    output_bucket = event.get('bucket').get('output')
+    bucket = event.get('bucket').get('bucket')
+    input_prefix = event.get('bucket').get('input')
+    output_prefix = event.get('bucket').get('output')
     key = unquote_plus(event.get('object').get('key'))
     width = event.get('object').get('width')
     height = event.get('object').get('height')
@@ -39,7 +40,7 @@ def handler(event):
     #resize_image(download_path, upload_path, width, height)
     #client.upload(output_bucket, key, upload_path)
     download_begin = datetime.datetime.now()
-    img = client.download_stream(input_bucket, key)
+    img = client.download_stream(bucket, os.path.join(input_prefix, key))
     download_end = datetime.datetime.now()
 
     process_begin = datetime.datetime.now()
@@ -48,7 +49,7 @@ def handler(event):
     process_end = datetime.datetime.now()
 
     upload_begin = datetime.datetime.now()
-    key_name = client.upload_stream(output_bucket, key, resized)
+    key_name = client.upload_stream(bucket, os.path.join(output_prefix, key), resized)
     upload_end = datetime.datetime.now()
 
     download_time = (download_end - download_begin) / datetime.timedelta(microseconds=1)
@@ -56,7 +57,7 @@ def handler(event):
     process_time = (process_end - process_begin) / datetime.timedelta(microseconds=1)
     return {
             'result': {
-                'bucket': output_bucket,
+                'bucket': bucket,
                 'key': key_name
             },
             'measurement': {

--- a/benchmarks/200.multimedia/220.video-processing/input.py
+++ b/benchmarks/200.multimedia/220.video-processing/input.py
@@ -12,7 +12,7 @@ def buckets_count():
     :param output_buckets:
     :param upload_func: upload function taking three params(bucket_idx, key, filepath)
 '''
-def generate_input(data_dir, size, input_buckets, output_buckets, upload_func):
+def generate_input(data_dir, size, benchmarks_bucket, input_paths, output_paths, upload_func):
     for file in glob.glob(os.path.join(data_dir, '*.mp4')):
         img = os.path.relpath(file, data_dir)
         upload_func(0, img, file)
@@ -21,6 +21,7 @@ def generate_input(data_dir, size, input_buckets, output_buckets, upload_func):
     input_config['object']['key'] = img
     input_config['object']['op'] = 'watermark'
     input_config['object']['duration'] = 1
-    input_config['bucket']['input'] = input_buckets[0]
-    input_config['bucket']['output'] = output_buckets[0]
+    input_config['bucket']['bucket'] = benchmarks_bucket
+    input_config['bucket']['input'] = input_paths[0]
+    input_config['bucket']['output'] = output_paths[0]
     return input_config

--- a/benchmarks/200.multimedia/220.video-processing/python/function.py
+++ b/benchmarks/200.multimedia/220.video-processing/python/function.py
@@ -52,6 +52,7 @@ def transcode_mp3(video, duration, event):
 operations = { 'transcode' : transcode_mp3, 'extract-gif' : to_gif, 'watermark' : watermark }
 
 def handler(event):
+
     bucket = event.get('bucket').get('bucket')
     input_prefix = event.get('bucket').get('input')
     output_prefix = event.get('bucket').get('output')
@@ -81,7 +82,7 @@ def handler(event):
     upload_begin = datetime.datetime.now()
     filename = os.path.basename(upload_path)
     upload_size = os.path.getsize(upload_path)
-    upload_key = client.upload(bucket, os.path.join(output_prefix, key), upload_path)
+    upload_key = client.upload(bucket, os.path.join(output_prefix, filename), upload_path)
     upload_stop = datetime.datetime.now()
 
     download_time = (download_stop - download_begin) / datetime.timedelta(microseconds=1)

--- a/benchmarks/300.utilities/311.compression/input.py
+++ b/benchmarks/300.utilities/311.compression/input.py
@@ -22,7 +22,7 @@ def upload_files(data_root, data_dir, upload_func):
     :param output_buckets:
     :param upload_func: upload function taking three params(bucket_idx, key, filepath)
 '''
-def generate_input(data_dir, size, input_buckets, output_buckets, upload_func):
+def generate_input(data_dir, size, benchmarks_bucket, input_paths, output_paths, upload_func):
 
     # upload different datasets
     datasets = []
@@ -32,6 +32,7 @@ def generate_input(data_dir, size, input_buckets, output_buckets, upload_func):
 
     input_config = {'object': {}, 'bucket': {}}
     input_config['object']['key'] = datasets[0]
-    input_config['bucket']['input'] = input_buckets[0]
-    input_config['bucket']['output'] = output_buckets[0]
+    input_config['bucket']['bucket'] = benchmarks_bucket
+    input_config['bucket']['input'] = input_paths[0]
+    input_config['bucket']['output'] = output_paths[0]
     return input_config

--- a/benchmarks/400.inference/411.image-recognition/input.py
+++ b/benchmarks/400.inference/411.image-recognition/input.py
@@ -21,7 +21,7 @@ def upload_files(data_root, data_dir, upload_func):
     :param output_buckets:
     :param upload_func: upload function taking three params(bucket_idx, key, filepath)
 '''
-def generate_input(data_dir, size, input_buckets, output_buckets, upload_func):
+def generate_input(data_dir, size, benchmarks_bucket, input_paths, output_paths, upload_func):
 
     # upload model
     model_name = 'resnet50-19c8e357.pth'
@@ -38,6 +38,7 @@ def generate_input(data_dir, size, input_buckets, output_buckets, upload_func):
     input_config = {'object': {}, 'bucket': {}}
     input_config['object']['model'] = model_name
     input_config['object']['input'] = input_images[0][0]
-    input_config['bucket']['model'] = input_buckets[0]
-    input_config['bucket']['input'] = input_buckets[1]
+    input_config['bucket']['bucket'] = benchmarks_bucket
+    input_config['bucket']['input'] = input_paths[1]
+    input_config['bucket']['model'] = input_paths[0]
     return input_config

--- a/benchmarks/400.inference/411.image-recognition/python/function.py
+++ b/benchmarks/400.inference/411.image-recognition/python/function.py
@@ -25,22 +25,23 @@ model = None
 
 def handler(event):
   
-    model_bucket = event.get('bucket').get('model')
-    input_bucket = event.get('bucket').get('input')
+    bucket = event.get('bucket').get('bucket')
+    input_prefix = event.get('bucket').get('input')
+    model_prefix = event.get('bucket').get('model')
     key = event.get('object').get('input')
     model_key = event.get('object').get('model')
     download_path = '/tmp/{}-{}'.format(key, uuid.uuid4())
 
     image_download_begin = datetime.datetime.now()
     image_path = download_path
-    client.download(input_bucket, key, download_path)
+    client.download(bucket, os.path.join(input_prefix, key), download_path)
     image_download_end = datetime.datetime.now()
 
     global model
     if not model:
         model_download_begin = datetime.datetime.now()
         model_path = os.path.join('/tmp', model_key)
-        client.download(model_bucket, model_key, model_path)
+        client.download(bucket, os.path.join(model_prefix, model_key), model_path)
         model_download_end = datetime.datetime.now()
         model_process_begin = datetime.datetime.now()
         model = resnet50(pretrained=False)

--- a/benchmarks/500.scientific/501.graph-pagerank/input.py
+++ b/benchmarks/500.scientific/501.graph-pagerank/input.py
@@ -5,7 +5,7 @@ size_generators = {
 }
 
 def buckets_count():
-    return (1, 1)
+    return (0, 0)
 
-def generate_input(data_dir, size, input_buckets, output_buckets, upload_func):
+def generate_input(data_dir, size, benchmarks_bucket, input_paths, output_paths, upload_func):
     return { 'size': size_generators[size] }

--- a/benchmarks/500.scientific/502.graph-mst/input.py
+++ b/benchmarks/500.scientific/502.graph-mst/input.py
@@ -5,7 +5,7 @@ size_generators = {
 }
 
 def buckets_count():
-    return (1, 1)
+    return (0, 0)
 
-def generate_input(data_dir, size, input_buckets, output_buckets, upload_func):
+def generate_input(data_dir, size, benchmarks_bucket, input_paths, output_paths, upload_func):
     return { 'size': size_generators[size] }

--- a/benchmarks/500.scientific/503.graph-bfs/input.py
+++ b/benchmarks/500.scientific/503.graph-bfs/input.py
@@ -5,7 +5,7 @@ size_generators = {
 }
 
 def buckets_count():
-    return (1, 1)
+    return (0, 0)
 
-def generate_input(data_dir, size, input_buckets, output_buckets, upload_func):
+def generate_input(data_dir, size, benchmarks_bucket, input_paths, output_paths, upload_func):
     return { 'size': size_generators[size] }

--- a/benchmarks/500.scientific/504.dna-visualisation/input.py
+++ b/benchmarks/500.scientific/504.dna-visualisation/input.py
@@ -3,12 +3,14 @@ import glob, os
 def buckets_count():
     return (1, 1)
 
-def generate_input(data_dir, size, input_buckets, output_buckets, upload_func):
+def generate_input(data_dir, size, benchmarks_bucket, input_paths, output_paths, upload_func):
+
     for file in glob.glob(os.path.join(data_dir, '*.fasta')):
         data = os.path.relpath(file, data_dir)
         upload_func(0, data, file)
     input_config = {'object': {}, 'bucket': {}}
     input_config['object']['key'] = data
-    input_config['bucket']['input'] = input_buckets[0]
-    input_config['bucket']['output'] = output_buckets[0]
+    input_config['bucket']['bucket'] = benchmarks_bucket
+    input_config['bucket']['input'] = input_paths[0]
+    input_config['bucket']['output'] = output_paths[0]
     return input_config

--- a/benchmarks/500.scientific/504.dna-visualisation/python/function.py
+++ b/benchmarks/500.scientific/504.dna-visualisation/python/function.py
@@ -1,4 +1,4 @@
-import datetime, io, json
+import datetime, io, json, os
 # using https://squiggle.readthedocs.io/en/latest/
 from squiggle import transform
 
@@ -7,13 +7,14 @@ client = storage.storage.get_instance()
 
 def handler(event):
 
-    input_bucket = event.get('bucket').get('input')
-    output_bucket = event.get('bucket').get('output')
+    bucket = event.get('bucket').get('bucket')
+    input_prefix = event.get('bucket').get('input')
+    output_prefix = event.get('bucket').get('output')
     key = event.get('object').get('key')
     download_path = '/tmp/{}'.format(key)
 
     download_begin = datetime.datetime.now()
-    client.download(input_bucket, key, download_path)
+    client.download(bucket, os.path.join(input_prefix, key), download_path)
     download_stop = datetime.datetime.now()
     data = open(download_path, "r").read()
 
@@ -24,20 +25,22 @@ def handler(event):
     upload_begin = datetime.datetime.now()
     buf = io.BytesIO(json.dumps(result).encode())
     buf.seek(0)
-    key_name = client.upload_stream(output_bucket, key, buf)
+    key_name = client.upload_stream(bucket, os.path.join(output_prefix, key), buf)
     upload_stop = datetime.datetime.now()
     buf.close()
 
     download_time = (download_stop - download_begin) / datetime.timedelta(microseconds=1)
+    upload_time = (upload_stop - upload_begin) / datetime.timedelta(microseconds=1)
     process_time = (process_end - process_begin) / datetime.timedelta(microseconds=1)
 
     return {
             'result': {
-                'bucket': output_bucket,
+                'bucket': bucket,
                 'key': key_name
             },
             'measurement': {
                 'download_time': download_time,
-                'compute_time': process_time
+                'compute_time': process_time,
+                'upload_time': process_time
             }
     }

--- a/benchmarks/wrappers/aws/nodejs/storage.js
+++ b/benchmarks/wrappers/aws/nodejs/storage.js
@@ -1,6 +1,7 @@
 
 const aws = require('aws-sdk'),
       fs = require('fs'),
+      path = require('path'),
       uuid = require('uuid'),
       util = require('util'),
       stream = require('stream');
@@ -12,9 +13,9 @@ class aws_storage {
   }
 
   unique_name(file) {
-    let [name, extension] = file.split('.');
+    let name = path.parse(file);
     let uuid_name = uuid.v4().split('-')[0];
-    return util.format('%s.%s.%s', name, uuid_name, extension);
+    return path.join(name.dir, util.format('%s.%s%s', name.name, uuid_name, name.ext));
   }
 
   upload(bucket, file, filepath) {

--- a/benchmarks/wrappers/aws/python/storage.py
+++ b/benchmarks/wrappers/aws/python/storage.py
@@ -15,7 +15,7 @@ class storage:
     @staticmethod
     def unique_name(name):
         name, extension = os.path.splitext(name)
-        return '{name}.{random}.{extension}'.format(
+        return '{name}.{random}{extension}'.format(
                     name=name,
                     extension=extension,
                     random=str(uuid.uuid4()).split('-')[0]

--- a/benchmarks/wrappers/aws/python/storage.py
+++ b/benchmarks/wrappers/aws/python/storage.py
@@ -20,12 +20,12 @@ class storage:
                     extension=extension,
                     random=str(uuid.uuid4()).split('-')[0]
                 )
-    
+
     def upload(self, bucket, file, filepath):
         key_name = storage.unique_name(file)
         self.client.upload_file(filepath, bucket, key_name)
         return key_name
-    
+
     def download(self, bucket, file, filepath):
         self.client.download_file(bucket, file, filepath)
 

--- a/benchmarks/wrappers/azure/nodejs/storage.js
+++ b/benchmarks/wrappers/azure/nodejs/storage.js
@@ -1,5 +1,6 @@
 
 const { BlobServiceClient } = require('@azure/storage-blob'),
+        path = require('path'),
         uuid = require('uuid'),
         util = require('util'),
         stream = require('stream');
@@ -13,9 +14,9 @@ class azure_storage {
   }
 
   unique_name(file) {
-    let [name, extension] = file.split('.');
+    let name = path.parse(file);
     let uuid_name = uuid.v4().split('-')[0];
-    return util.format('%s.%s.%s', name, uuid_name, extension);
+    return path.join(name.dir, util.format('%s.%s%s', name.name, uuid_name, name.ext));
   }
 
   upload(container, file, filepath) {

--- a/benchmarks/wrappers/azure/python/storage.py
+++ b/benchmarks/wrappers/azure/python/storage.py
@@ -15,8 +15,8 @@ class storage:
 
     @staticmethod
     def unique_name(name):
-        name, extension = os.path.splitext('.')
-        return '{name}.{random}.{extension}'.format(
+        name, extension = os.path.splitext(name)
+        return '{name}.{random}{extension}'.format(
                     name=name,
                     extension=extension,
                     random=str(uuid.uuid4()).split('-')[0]

--- a/benchmarks/wrappers/gcp/nodejs/storage.js
+++ b/benchmarks/wrappers/gcp/nodejs/storage.js
@@ -36,8 +36,21 @@ class gcp_storage {
     var file = bucket.file(uniqueName);
     let upload = file.createWriteStream();
     var write_stream = new stream.PassThrough();
+
     write_stream.pipe(upload);
-    return [write_stream, Promise.resolve(upload), uniqueName];
+
+    const promise = new Promise((resolve, reject) => {
+      upload.on('error', err => {
+        upload.end();
+        reject(err);
+      });
+
+      upload.on('finish', () => {
+        upload.end();
+        resolve(file.name);
+      });
+    });
+    return [write_stream, promise, uniqueName];
   };
 
   downloadStream(container, file) {

--- a/benchmarks/wrappers/gcp/nodejs/storage.js
+++ b/benchmarks/wrappers/gcp/nodejs/storage.js
@@ -1,5 +1,6 @@
 const { Storage } = require('@google-cloud/storage'),
         fs = require('fs'),
+        path = require('path'),
         uuid = require('uuid'),
         util = require('util'),
         stream = require('stream');
@@ -11,9 +12,9 @@ class gcp_storage {
   }
 
   unique_name(file) {
-    let [name, extension] = file.split('.');
+    let name = path.parse(file);
     let uuid_name = uuid.v4().split('-')[0];
-    return util.format('%s.%s.%s', name, uuid_name, extension);
+    return path.join(name.dir, util.format('%s.%s%s', name.name, uuid_name, name.ext));
   }
 
   upload(container, file, filepath) {

--- a/benchmarks/wrappers/local/nodejs/storage.js
+++ b/benchmarks/wrappers/local/nodejs/storage.js
@@ -1,5 +1,6 @@
 
 const minio = require('minio'),
+      path = require('path'),
       uuid = require('uuid'),
       util = require('util'),
       stream = require('stream');
@@ -22,9 +23,9 @@ class minio_storage {
   }
 
   unique_name(file) {
-    let [name, extension] = file.split('.');
+    let name = path.parse(file);
     let uuid_name = uuid.v4().split('-')[0];
-    return util.format('%s.%s.%s', name, uuid_name, extension);
+    return path.join(name.dir, util.format('%s.%s%s', name.name, uuid_name, name.ext));
   }
 
   upload(bucket, file, filepath) {

--- a/benchmarks/wrappers/local/python/storage.py
+++ b/benchmarks/wrappers/local/python/storage.py
@@ -21,8 +21,8 @@ class storage:
 
     @staticmethod
     def unique_name(name):
-        name, extension = name.split('.')
-        return '{name}.{random}.{extension}'.format(
+        name, extension = os.path.splitext(name)
+        return '{name}.{random}{extension}'.format(
                     name=name,
                     extension=extension,
                     random=str(uuid.uuid4()).split('-')[0]

--- a/benchmarks/wrappers/openwhisk/nodejs/storage.js
+++ b/benchmarks/wrappers/openwhisk/nodejs/storage.js
@@ -1,5 +1,6 @@
 
 const minio = require('minio'),
+  path = require('path'),
   uuid = require('uuid'),
   util = require('util'),
   stream = require('stream'),
@@ -24,9 +25,9 @@ class minio_storage {
   }
 
   unique_name(file) {
-    let [name, extension] = file.split('.');
+    let name = path.parse(file);
     let uuid_name = uuid.v4().split('-')[0];
-    return util.format('%s.%s.%s', name, uuid_name, extension);
+    return path.join(name.dir, util.format('%s.%s%s', name.name, uuid_name, name.ext));
   }
 
   upload(bucket, file, filepath) {

--- a/benchmarks/wrappers/openwhisk/python/storage.py
+++ b/benchmarks/wrappers/openwhisk/python/storage.py
@@ -40,10 +40,13 @@ class storage:
 
     @staticmethod
     def unique_name(name):
-        name, extension = name.split(".")
-        return "{name}.{random}.{extension}".format(
-            name=name, extension=extension, random=str(uuid.uuid4()).split("-")[0]
-        )
+        name, extension = os.path.splitext(name)
+        return '{name}.{random}{extension}'.format(
+                    name=name,
+                    extension=extension,
+                    random=str(uuid.uuid4()).split('-')[0]
+                )
+
 
     def upload(self, bucket, file, filepath):
         key_name = storage.unique_name(file)

--- a/config/systems.json
+++ b/config/systems.json
@@ -229,7 +229,7 @@
             "storage.js"
           ],
           "packages": {
-            "minio": "^7.0.16"
+            "minio": "7.0.16"
           }
         }
       }

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -106,8 +106,11 @@ or in the JSON input configuration:
 }
 ```
 
-> **Warning**
+> [!WARNING]
 > The tool assumes there is only one subscription active on the account. If you want to bind the newly created service principal to a specific subscription, or the created credentials do not work with SeBS and you see errors such as "No subscriptions found for X", then you must specify a subscription when creating the service principal. Check your subscription ID on in the Azure portal, and use the CLI option `tools/create_azure_credentials.py --subscription <SUBSCRIPTION_ID>`.
+
+> [!WARNING]
+> When you log in for the first time on a device, Microsoft might require authenticating your login with Multi-Factor Authentication (MFA). In this case, we will return an error such as: "The following tenants require Multi-Factor Authentication (MFA). Use 'az login --tenant TENANT_ID' to explicitly login to a tenant.". Then, you can pass the tenant ID by using the `--tenant <tenant-id>` flag.
 
 ### Resources
 

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -154,14 +154,32 @@ or in the JSON input configuration:
 ## OpenWhisk
 
 SeBS expects users to deploy and configure an OpenWhisk instance.
-In `tools/openwhisk_preparation.py`, we include scripts that help install
-[kind (Kubernetes in Docker)](https://kind.sigs.k8s.io/) and deploy
-OpenWhisk on a `kind` cluster.
+Below, you will find example of instruction for deploying OpenWhisk instance.
 The configuration parameters of OpenWhisk for SeBS can be found
 in `config/example.json` under the key `['deployment']['openwhisk']`.
 In the subsections below, we discuss the meaning and use of each parameter.
 To correctly deploy SeBS functions to OpenWhisk, following the
 subsections on *Toolchain* and *Docker* configuration is particularly important.
+
+> [!WARNING]
+> Some benchmarks might require larger memory allocations, e.g., 2048 MB. Not all OpenWhisk deployments support this out-of-the-box.
+> The deployment section below shows an example of changing the default function memory limit from 512 MB to a higher value.
+
+### Deployment
+
+In `tools/openwhisk_preparation.py`, we include scripts that help install
+[kind (Kubernetes in Docker)](https://kind.sigs.k8s.io/) and deploy
+OpenWhisk on a `kind` cluster. Alternatively, you can deploy to an existing
+cluster by [using offical deployment instructions](https://github.com/apache/openwhisk-deploy-kube/blob/master/docs/k8s-kind.md):
+
+```shell
+./deploy/kind/start-kind.sh
+helm install owdev ./helm/openwhisk -n openwhisk --create-namespace -f deploy/kind/mycluster.yaml
+kubectl get pods -n openwhisk --watch
+```
+
+To change the maximum memory allocation per function, edit the `max` value under `memory` in file `helm/openwhisk/values.yaml`.
+To run all benchmarks, we recommend of at least "2048m".
 
 ### Toolchain
 

--- a/requirements.aws.txt
+++ b/requirements.aws.txt
@@ -1,4 +1,6 @@
 boto3
+botocore
+flake8-boto3
 urllib3
 boto3-stubs
 boto3-stubs[lambda,s3,apigatewayv2,sts,logs,iam]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ mypy
 types-pycurl
 types-requests
 types-PyYAML
+types-urllib3
 #
 pandas>=1.1.3
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ docker>=4.2.0
 tzlocal>=2.1
 #linting
 flake8
-flake8-boto3
 black==22.8.0
 flake8-black
 mypy

--- a/sebs.py
+++ b/sebs.py
@@ -91,6 +91,12 @@ def common_params(func):
         type=click.Choice(["azure", "aws", "gcp", "local", "openwhisk"]),
         help="Cloud deployment to use.",
     )
+    @click.option(
+        "--resource-prefix",
+        default=None,
+        type=str,
+        help="Resource prefix to look for.",
+    )
     @simplified_common_params
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
@@ -111,6 +117,7 @@ def parse_common_params(
     deployment,
     language,
     language_version,
+    resource_prefix: Optional[str] = None,
     initialize_deployment: bool = True,
     ignore_cache: bool = False,
 ):
@@ -136,7 +143,7 @@ def parse_common_params(
         deployment_client = sebs_client.get_deployment(
             config_obj["deployment"], logging_filename=logging_filename
         )
-        deployment_client.initialize()
+        deployment_client.initialize(resource_prefix=resource_prefix)
     else:
         deployment_client = None
 

--- a/sebs.py
+++ b/sebs.py
@@ -501,8 +501,12 @@ def resources():
 
 
 @resources.command("list")
+@click.argument(
+    "resource",
+    type=click.Choice(["buckets", "resource-groups"])
+)
 @common_params
-def resources_list(**kwargs):
+def resources_list(resource, **kwargs):
 
     (
         config,
@@ -512,11 +516,23 @@ def resources_list(**kwargs):
         deployment_client,
     ) = parse_common_params(**kwargs)
 
-    storage_client = deployment_client.get_storage(False)
-    buckets = storage_client.list_buckets()
-    sebs_client.logging.info("Storage buckets:")
-    for idx, bucket in enumerate(buckets):
-        sebs_client.logging.info(f"({idx}) {bucket}")
+    if resource == "buckets":
+        storage_client = deployment_client.get_storage(False)
+        buckets = storage_client.list_buckets()
+        sebs_client.logging.info("Storage buckets:")
+        for idx, bucket in enumerate(buckets):
+            sebs_client.logging.info(f"({idx}) {bucket}")
+
+    elif resource == "resource-groups":
+
+        if deployment_client.name() != "azure":
+            sebs_client.logging.error("Resource groups are only supported on Azure!")
+            return
+
+        groups = deployment_client.config.resources.list_resource_groups(deployment_client.cli_instance)
+        sebs_client.logging.info("Resource grup:")
+        for idx, bucket in enumerate(groups):
+            sebs_client.logging.info(f"({idx}) {bucket}")
 
 
 @resources.command("remove")

--- a/sebs.py
+++ b/sebs.py
@@ -354,7 +354,9 @@ def storage_start(storage, output_json, port):
 
     sebs.utils.global_logging()
     storage_type = sebs.SeBS.get_storage_implementation(StorageTypes(storage))
-    storage_instance = storage_type(docker.from_env(), None, True)
+    storage_config = sebs.SeBS.get_storage_config_implementation(StorageTypes(storage))()
+
+    storage_instance = storage_type(docker.from_env(), None, storage_config.resources, True)
     logging.info(f"Starting storage {str(storage)} on port {port}.")
     storage_instance.start(port)
     if output_json:
@@ -376,7 +378,7 @@ def storage_stop(input_json):
         storage_type = cfg["type"]
         storage_cfg = sebs.SeBS.get_storage_config_implementation(storage_type).deserialize(cfg)
         logging.info(f"Stopping storage deployment of {storage_type}.")
-        storage = sebs.SeBS.get_storage_implementation(storage_type).deserialize(storage_cfg, None)
+        storage = sebs.SeBS.get_storage_implementation(storage_type).deserialize(storage_cfg, None, storage_cfg.resources)
         storage.stop()
         logging.info(f"Stopped storage deployment of {storage_type}.")
 
@@ -481,7 +483,7 @@ def experiment_invoke(experiment, **kwargs):
 @click.argument("experiment", type=str)  # , help="Benchmark to be launched.")
 @click.option("--extend-time-interval", type=int, default=-1)  # , help="Benchmark to be launched.")
 @common_params
-def experment_process(experiment, extend_time_interval, **kwargs):
+def experiment_process(experiment, extend_time_interval, **kwargs):
     (
         config,
         output_dir,

--- a/sebs/aws/aws.py
+++ b/sebs/aws/aws.py
@@ -62,7 +62,7 @@ class AWS(System):
         self._config = config
         self.storage: Optional[S3] = None
 
-    def initialize(self, config: Dict[str, str] = {}):
+    def initialize(self, config: Dict[str, str] = {}, resource_prefix: Optional[str] = None):
         # thread-safe
         self.session = boto3.session.Session(
             aws_access_key_id=self.config.credentials.access_key,
@@ -70,6 +70,7 @@ class AWS(System):
         )
         self.get_lambda_client()
         self.get_storage()
+        self.initialize_resources(self.get_storage(), select_prefix=resource_prefix)
 
     def get_lambda_client(self):
         if not hasattr(self, "client"):

--- a/sebs/aws/aws.py
+++ b/sebs/aws/aws.py
@@ -70,7 +70,7 @@ class AWS(System):
         )
         self.get_lambda_client()
         self.get_storage()
-        self.initialize_resources(self.get_storage(), select_prefix=resource_prefix)
+        self.initialize_resources(select_prefix=resource_prefix)
 
     def get_lambda_client(self):
         if not hasattr(self, "client"):

--- a/sebs/aws/aws.py
+++ b/sebs/aws/aws.py
@@ -94,6 +94,7 @@ class AWS(System):
             self.storage = S3(
                 self.session,
                 self.cache_client,
+                self.config.resources,
                 self.config.region,
                 access_key=self.config.credentials.access_key,
                 secret_key=self.config.credentials.secret_key,

--- a/sebs/aws/config.py
+++ b/sebs/aws/config.py
@@ -242,6 +242,7 @@ class AWSResources(Resources):
                 ret.logging_handlers = handlers
                 ret.logging.info("No cached resources for AWS found, using user configuration.")
             else:
+                AWSResources.initialize(ret, {})
                 ret.logging_handlers = handlers
                 ret.logging.info("No resources for AWS found, initialize!")
 
@@ -250,7 +251,7 @@ class AWSResources(Resources):
 
 class AWSConfig(Config):
     def __init__(self, credentials: AWSCredentials, resources: AWSResources):
-        super().__init__()
+        super().__init__(name="aws")
         self._credentials = credentials
         self._resources = resources
 

--- a/sebs/aws/function.py
+++ b/sebs/aws/function.py
@@ -1,6 +1,7 @@
 from typing import cast, Optional
 
 from sebs.aws.s3 import S3
+from sebs.faas.config import Resources
 from sebs.faas.function import Function, FunctionConfig
 
 
@@ -61,5 +62,5 @@ class LambdaFunction(Function):
         return ret
 
     def code_bucket(self, benchmark: str, storage_client: S3):
-        self.bucket, idx = storage_client.add_input_bucket(benchmark)
+        self.bucket = storage_client.get_bucket(Resources.StorageBucketType.DEPLOYMENT)
         return self.bucket

--- a/sebs/aws/s3.py
+++ b/sebs/aws/s3.py
@@ -1,6 +1,6 @@
 import os
 import uuid
-from typing import List
+from typing import List, Optional
 
 import boto3
 
@@ -129,9 +129,12 @@ class S3(PersistentStorage):
             objects = []
         return objects
 
-    def list_buckets(self, bucket_name: str) -> List[str]:
+    def list_buckets(self, bucket_name: Optional[str] = None) -> List[str]:
         s3_buckets = self.client.list_buckets()["Buckets"]
-        return [bucket["Name"] for bucket in s3_buckets if bucket_name in bucket["Name"]]
+        if bucket_name is not None:
+            return [bucket["Name"] for bucket in s3_buckets if bucket_name in bucket["Name"]]
+        else:
+            return [bucket["Name"] for bucket in s3_buckets]
 
     def clean_bucket(self, bucket: str):
         objects = self.client.list_objects_v2(Bucket=bucket)

--- a/sebs/aws/s3.py
+++ b/sebs/aws/s3.py
@@ -95,7 +95,7 @@ class S3(PersistentStorage):
 
         key = os.path.join(self.input_prefixes[path_idx], key)
 
-        bucket_name = self.benchmarks_bucket()
+        bucket_name = self.get_bucket(Resources.StorageBucketType.BENCHMARKS)
         if not self.replace_existing:
             for f in self.input_prefixes_files[path_idx]:
                 f_name = f

--- a/sebs/aws/s3.py
+++ b/sebs/aws/s3.py
@@ -141,3 +141,6 @@ class S3(PersistentStorage):
         if "Contents" in objects:
             objects = [{"Key": obj["Key"]} for obj in objects["Contents"]]  # type: ignore
             self.client.delete_objects(Bucket=bucket, Delete={"Objects": objects})  # type: ignore
+
+    def remove_bucket(self, bucket: str):
+        self.client.delete_bucket(Bucket=bucket)

--- a/sebs/azure/azure.py
+++ b/sebs/azure/azure.py
@@ -106,6 +106,7 @@ class Azure(System):
             self.storage = BlobStorage(
                 self.config.region,
                 self.cache_client,
+                self.config.resources,
                 self.config.resources.data_storage_account(self.cli_instance).connection_string,
                 replace_existing=replace_existing,
             )
@@ -280,7 +281,7 @@ class Azure(System):
                 code_package.benchmark,
                 code_package.language_name,
                 code_package.language_version,
-                self.config.resources_id,
+                self.config.resources.resources_id,
             )
             .replace(".", "-")
             .replace("_", "-")

--- a/sebs/azure/azure.py
+++ b/sebs/azure/azure.py
@@ -82,7 +82,7 @@ class Azure(System):
 
     """
         Allow multiple deployment clients share the same settings.
-        Not an ideal situation,
+        Not an ideal situation, but makes regression testing much simpler.
     """
 
     def allocate_shared_resource(self):

--- a/sebs/azure/azure.py
+++ b/sebs/azure/azure.py
@@ -87,7 +87,7 @@ class Azure(System):
     def find_deployments(self) -> List[str]:
 
         """
-            Look for duplicated resource groups.
+        Look for duplicated resource groups.
         """
         resource_groups = self.config.resources.list_resource_groups(self.cli_instance)
         deployments = []

--- a/sebs/azure/azure.py
+++ b/sebs/azure/azure.py
@@ -60,8 +60,14 @@ class Azure(System):
         Start the Docker container running Azure CLI tools.
     """
 
-    def initialize(self, config: Dict[str, str] = {}, resource_prefix: Optional[str] = None):
-        self.cli_instance = AzureCLI(self.system_config, self.docker_client)
+    def initialize(self, cli: Optional[AzureCLI] = None, config: Dict[str, str] = {}, resource_prefix: Optional[str] = None):
+        if cli is None:
+            self.cli_instance = AzureCLI(self.system_config, self.docker_client)
+            self.cli_instance_stop = True
+        else:
+            self.cli_instance = cli
+            self.cli_instance_stop = False
+
         output = self.cli_instance.login(
             appId=self.config.credentials.appId,
             tenant=self.config.credentials.tenant,
@@ -80,7 +86,7 @@ class Azure(System):
         self.allocate_shared_resource()
 
     def shutdown(self):
-        if self.cli_instance:
+        if self.cli_instance and self.cli_instance_stop:
             self.cli_instance.shutdown()
         super().shutdown()
 

--- a/sebs/azure/azure.py
+++ b/sebs/azure/azure.py
@@ -56,17 +56,22 @@ class Azure(System):
         self.logging_handlers = logger_handlers
         self._config = config
 
+    def initialize_cli(self, cli: AzureCLI):
+        self.cli_instance = cli
+        self.cli_instance_stop = False
+
     """
         Start the Docker container running Azure CLI tools.
     """
 
-    def initialize(self, cli: Optional[AzureCLI] = None, config: Dict[str, str] = {}, resource_prefix: Optional[str] = None):
-        if cli is None:
+    def initialize(
+        self,
+        config: Dict[str, str] = {},
+        resource_prefix: Optional[str] = None,
+    ):
+        if not hasattr(self, "cli_instance"):
             self.cli_instance = AzureCLI(self.system_config, self.docker_client)
             self.cli_instance_stop = True
-        else:
-            self.cli_instance = cli
-            self.cli_instance_stop = False
 
         output = self.cli_instance.login(
             appId=self.config.credentials.appId,

--- a/sebs/azure/blob_storage.py
+++ b/sebs/azure/blob_storage.py
@@ -68,7 +68,8 @@ class BlobStorage(PersistentStorage):
         if self.cached and not self.replace_existing:
             return
 
-        container_name = os.path.join(self.input_prefixes[container_idx], file)
+        container_name = self.get_bucket(Resources.StorageBucketType.BENCHMARKS)
+        key = os.path.join(self.input_prefixes[container_idx], file)
         if not self.replace_existing:
             for f in self.input_prefixes_files[container_idx]:
                 if f == file:
@@ -76,7 +77,7 @@ class BlobStorage(PersistentStorage):
                         "Skipping upload of {} to {}".format(filepath, container_name)
                     )
                     return
-        client = self.client.get_blob_client(container_name, file)
+        client = self.client.get_blob_client(container_name, key)
         with open(filepath, "rb") as file_data:
             client.upload_blob(data=file_data, overwrite=True)
         self.logging.info("Upload {} to {}".format(filepath, container_name))

--- a/sebs/azure/blob_storage.py
+++ b/sebs/azure/blob_storage.py
@@ -1,3 +1,4 @@
+import os
 import uuid
 from typing import List, Optional
 
@@ -60,17 +61,14 @@ class BlobStorage(PersistentStorage):
                 for container in self.client.list_containers(name_starts_with=bucket_name)
             ]
         else:
-            return [
-                container["name"]
-                for container in self.client.list_containers()
-            ]
+            return [container["name"] for container in self.client.list_containers()]
 
     def uploader_func(self, container_idx, file, filepath):
         # Skip upload when using cached containers
         if self.cached and not self.replace_existing:
             return
 
-        container_name = os.path.join(self.input_prefixes[path_idx], key)
+        container_name = os.path.join(self.input_prefixes[container_idx], file)
         if not self.replace_existing:
             for f in self.input_prefixes_files[container_idx]:
                 if f == file:

--- a/sebs/azure/blob_storage.py
+++ b/sebs/azure/blob_storage.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import List
+from typing import List, Optional
 
 from azure.storage.blob import BlobServiceClient
 
@@ -53,19 +53,26 @@ class BlobStorage(PersistentStorage):
     def correct_name(self, name: str) -> str:
         return name.replace(".", "-")
 
-    def list_buckets(self, bucket_name: str) -> List[str]:
-        return [
-            container["name"]
-            for container in self.client.list_containers(name_starts_with=bucket_name)
-        ]
+    def list_buckets(self, bucket_name: Optional[str] = None) -> List[str]:
+        if bucket_name is not None:
+            return [
+                container["name"]
+                for container in self.client.list_containers(name_starts_with=bucket_name)
+            ]
+        else:
+            return [
+                container["name"]
+                for container in self.client.list_containers()
+            ]
 
     def uploader_func(self, container_idx, file, filepath):
         # Skip upload when using cached containers
         if self.cached and not self.replace_existing:
             return
-        container_name = self.input_buckets[container_idx]
+
+        container_name = os.path.join(self.input_prefixes[path_idx], key)
         if not self.replace_existing:
-            for f in self.input_buckets_files[container_idx]:
+            for f in self.input_prefixes_files[container_idx]:
                 if f == file:
                     self.logging.info(
                         "Skipping upload of {} to {}".format(filepath, container_name)
@@ -106,14 +113,14 @@ class BlobStorage(PersistentStorage):
         :return: list of file names. empty if container empty
     """
 
-    def list_bucket(self, container: str):
+    def list_bucket(self, container: str, prefix: str = ""):
         objects = list(
             map(
                 lambda x: x["name"],
                 self.client.get_container_client(container).list_blobs(),
             )
         )
-        return objects
+        return [x for x in objects if prefix in x]
 
     def clean_bucket(self, bucket: str):
         self.logging.info("Clean output container {}".format(bucket))
@@ -121,3 +128,6 @@ class BlobStorage(PersistentStorage):
         blobs = list(map(lambda x: x["name"], container_client.list_blobs()))
         if len(blobs) > 0:
             container_client.delete_blobs(*blobs)
+
+    def remove_bucket(self, bucket: str):
+        self.client.get_container_client(bucket).delete_container()

--- a/sebs/azure/config.py
+++ b/sebs/azure/config.py
@@ -211,9 +211,7 @@ class AzureResources(Resources):
             self.logging.error(ret.decode())
             raise RuntimeError("Failed to parse response from Azure CLI!")
 
-    def delete_resource_group(
-        self, cli_instance: AzureCLI, name: str, wait: bool = True
-    ) -> List[str]:
+    def delete_resource_group(self, cli_instance: AzureCLI, name: str, wait: bool = True):
 
         cmd = "az group delete -y --name {0}".format(name)
         if not wait:
@@ -223,8 +221,6 @@ class AzureResources(Resources):
             self.logging.error("Failed to delete the resource group!")
             self.logging.error(ret.decode())
             raise RuntimeError("Failed to delete the resource group!")
-
-        return
 
     """
         Retrieve or create storage account associated with benchmark data.

--- a/sebs/azure/config.py
+++ b/sebs/azure/config.py
@@ -211,6 +211,21 @@ class AzureResources(Resources):
             self.logging.error(ret.decode())
             raise RuntimeError("Failed to parse response from Azure CLI!")
 
+    def delete_resource_group(
+        self, cli_instance: AzureCLI, name: str, wait: bool = True
+    ) -> List[str]:
+
+        cmd = "az group delete -y --name {0}".format(name)
+        if not wait:
+            cmd += " --no-wait"
+        ret = cli_instance.execute(cmd)
+        if len(ret) != 0:
+            self.logging.error("Failed to delete the resource group!")
+            self.logging.error(ret.decode())
+            raise RuntimeError("Failed to delete the resource group!")
+
+        return
+
     """
         Retrieve or create storage account associated with benchmark data.
         Last argument allows to override the resource - useful when handling

--- a/sebs/azure/config.py
+++ b/sebs/azure/config.py
@@ -182,9 +182,7 @@ class AzureResources(Resources):
 
             groups = self.list_resource_groups(cli_instance)
             if self._resource_group in groups:
-                self.logging.info(
-                    "Using existing resource group {}.".format(self._resource_group)
-                )
+                self.logging.info("Using existing resource group {}.".format(self._resource_group))
             else:
                 self.logging.info(
                     "Starting allocation of resource group {}.".format(self._resource_group)
@@ -197,18 +195,18 @@ class AzureResources(Resources):
                 self.logging.info("Resource group {} created.".format(self._resource_group))
         return self._resource_group
 
-    def list_resource_groups(self, cli_instance: AzureCLI) -> str:
+    def list_resource_groups(self, cli_instance: AzureCLI) -> List[str]:
 
         ret = cli_instance.execute(
-            "az group list --query \"[?starts_with(name,'sebs_resource_group_') && location=='{0}']\""
-            .format(
+            "az group list --query "
+            "\"[?starts_with(name,'sebs_resource_group_') && location=='{0}']\"".format(
                 self._region
             )
         )
         try:
             resource_groups = json.loads(ret.decode())
             return [x["name"] for x in resource_groups]
-        except:
+        except Exception:
             self.logging.error("Failed to parse the response!")
             self.logging.error(ret.decode())
             raise RuntimeError("Failed to parse response from Azure CLI!")
@@ -223,7 +221,7 @@ class AzureResources(Resources):
         if not self._data_storage_account:
 
             # remove non-numerical and non-alphabetic characters
-            parsed = re.compile('[^a-zA-Z0-9]').sub('', self.resources_id)
+            parsed = re.compile("[^a-zA-Z0-9]").sub("", self.resources_id)
 
             account_name = "storage{}".format(parsed)
             self._data_storage_account = self._create_storage_account(cli_instance, account_name)
@@ -232,16 +230,14 @@ class AzureResources(Resources):
     def list_storage_accounts(self, cli_instance: AzureCLI) -> List[str]:
 
         ret = cli_instance.execute(
-            (
-                "az storage account list --resource-group {0}"
-            ).format(
+            ("az storage account list --resource-group {0}").format(
                 self.resource_group(cli_instance)
             )
         )
         try:
             storage_accounts = json.loads(ret.decode())
             return [x["name"] for x in storage_accounts]
-        except:
+        except Exception:
             self.logging.error("Failed to parse the response!")
             self.logging.error(ret.decode())
             raise RuntimeError("Failed to parse response from Azure CLI!")
@@ -267,7 +263,9 @@ class AzureResources(Resources):
         does NOT add the account to any resource collection.
     """
 
-    def _create_storage_account(self, cli_instance: AzureCLI, account_name: str) -> "AzureResources.Storage":
+    def _create_storage_account(
+        self, cli_instance: AzureCLI, account_name: str
+    ) -> "AzureResources.Storage":
         sku = "Standard_LRS"
         self.logging.info("Starting allocation of storage account {}.".format(account_name))
         cli_instance.execute(
@@ -309,7 +307,9 @@ class AzureResources(Resources):
         else:
             ret._storage_accounts = []
         if "data_storage_account" in dct:
-            ret._data_storage_account = AzureResources.Storage.deserialize(dct["data_storage_account"])
+            ret._data_storage_account = AzureResources.Storage.deserialize(
+                dct["data_storage_account"]
+            )
 
     def serialize(self) -> dict:
         out = super().serialize()

--- a/sebs/benchmark.py
+++ b/sebs/benchmark.py
@@ -11,6 +11,7 @@ import docker
 
 from sebs.config import SeBSConfig
 from sebs.cache import Cache
+from sebs.faas.config import Resources
 from sebs.utils import find_benchmark, project_absolute_path, LoggingBase
 from sebs.faas.storage import PersistentStorage
 from typing import TYPE_CHECKING
@@ -549,7 +550,7 @@ class Benchmark(LoggingBase):
         input_config = mod.generate_input(
             benchmark_data_path,
             size,
-            storage.benchmarks_bucket(),
+            storage.get_bucket(Resources.StorageBucketType.BENCHMARKS),
             input,
             output,
             storage.uploader_func,

--- a/sebs/benchmark.py
+++ b/sebs/benchmark.py
@@ -539,16 +539,34 @@ class Benchmark(LoggingBase):
     def prepare_input(self, storage: PersistentStorage, size: str):
         benchmark_data_path = find_benchmark(self._benchmark, "benchmarks-data")
         mod = load_benchmark_input(self._benchmark_path)
+
         buckets = mod.buckets_count()
-        storage.allocate_buckets(self.benchmark, buckets)
+        input, output = storage.benchmark_data(self.benchmark, buckets)
+
+        # buckets = mod.buckets_count()
+        # storage.allocate_buckets(self.benchmark, buckets)
         # Get JSON and upload data as required by benchmark
         input_config = mod.generate_input(
             benchmark_data_path,
             size,
-            storage.input,
-            storage.output,
+            storage.benchmarks_bucket(),
+            input,
+            output,
             storage.uploader_func,
         )
+
+        self._cache_client.update_storage(
+            storage.deployment_name(),
+            self._benchmark,
+            {
+                "buckets": {
+                    "input": storage.input_prefixes,
+                    "output": storage.output_prefixes,
+                    "input_uploaded": True,
+                }
+            },
+        )
+
         return input_config
 
     """
@@ -625,8 +643,9 @@ class BenchmarkModuleInterface:
     def generate_input(
         data_dir: str,
         size: str,
-        input_buckets: List[str],
-        output_buckets: List[str],
+        benchmarks_bucket: str,
+        input_paths: List[str],
+        output_paths: List[str],
         upload_func: Callable[[int, str, str], None],
     ) -> Dict[str, str]:
         pass

--- a/sebs/benchmark.py
+++ b/sebs/benchmark.py
@@ -504,7 +504,7 @@ class Benchmark(LoggingBase):
             self.language_name,
             self.language_version,
             self.benchmark,
-            self.is_cached,
+            self.is_cached_valid,
         )
         self.logging.info(
             (

--- a/sebs/faas/config.py
+++ b/sebs/faas/config.py
@@ -129,13 +129,18 @@ class Resources(ABC, LoggingBase):
 
     @abstractmethod
     def serialize(self) -> dict:
-        out = {"resources_id": self.resources_id}
+        out = {}
+        if self.has_resources_id:
+            out["resources_id"] = self.resources_id
         for key, value in self._buckets.items():
             out[key.value] = value
         return out
 
     def update_cache(self, cache: Cache):
-        cache.update_config(val=self.resources_id, keys=[self._name, "resources", "resources_id"])
+        if self.has_resources_id:
+            cache.update_config(
+                val=self.resources_id, keys=[self._name, "resources", "resources_id"]
+            )
         for key, value in self._buckets.items():
             cache.update_config(
                 val=value, keys=[self._name, "resources", "storage_buckets", key.value]

--- a/sebs/faas/config.py
+++ b/sebs/faas/config.py
@@ -1,6 +1,10 @@
 from abc import ABC
 from abc import abstractmethod
 
+from enum import Enum
+from typing import Dict, Optional
+import uuid
+
 from sebs.cache import Cache
 from sebs.utils import has_platform, LoggingBase, LoggingHandlers
 
@@ -51,8 +55,62 @@ class Credentials(ABC, LoggingBase):
 
 
 class Resources(ABC, LoggingBase):
-    def __init__(self):
+    class StorageBucketType(str, Enum):
+        DEPLOYMENT = "deployment"
+        BENCHMARKS = "benchmarks"
+        EXPERIMENTS = "experiments"
+
+        @staticmethod
+        def deserialize(val: str) -> Resources.StorageBucketType:
+            for member in Resources.StorageBucketType:
+                if member.value == val:
+                    return member
+            raise Exception(f"Unknown storage bucket type type {val}")
+
+    def __init__(self, name: str):
         super().__init__()
+        self._name = name
+        self._buckets: Dict[Resources.StorageBucketType, str] = {}
+        self._resources_id = ""
+
+    @property
+    def resources_id(self) -> str:
+        return self._resources_id
+
+    @resources_id.setter
+    def resources_id(self, resources_id: str):
+        self._resources_id = resources_id
+
+    @property
+    def region(self) -> str:
+        return self._region
+
+    @region.setter
+    def region(self, region: str):
+        self._region = region
+
+    def get_storage_bucket(self, bucket_type: Resources.StorageBucketType) -> Optional[str]:
+        return self._buckets.get(bucket_type)
+
+    def get_storage_bucket_name(self, bucket_type: Resources.StorageBucketType) -> str:
+        return f"sebs-{bucket_type.value}-{self._resources_id}"
+
+    def set_storage_bucket(self, bucket_type: Resources.StorageBucketType, bucket_name: str):
+        self._buckets[bucket_type] = bucket_name
+
+    @staticmethod
+    @abstractmethod
+    def initialize(res: Resources, dct: dict):
+        if "resources_id" in dct:
+            res._resources_id = dct["resources_id"]
+        else:
+            res._resources_id = str(uuid.uuid1())[0:8]
+            res.logging.info(
+                f"Generating unique resource name for " f"the experiments: {res._resources_id}"
+            )
+        if "storage_buckets" in dct:
+            for key, value in dct["storage_buckets"].items():
+                res._buckets[Resources.StorageBucketType.deserialize(key)] = value
 
     """
         Create credentials instance from user config and cached values.
@@ -69,7 +127,17 @@ class Resources(ABC, LoggingBase):
 
     @abstractmethod
     def serialize(self) -> dict:
-        pass
+        out = {"resources_id": self.resources_id}
+        for key, value in self._buckets.items():
+            out[key.value] = value
+        return out
+
+    def update_cache(self, cache: Cache):
+        cache.update_config(val=self.resources_id, keys=[self._name, "resources", "resources_id"])
+        for key, value in self._buckets.items():
+            cache.update_config(
+                val=value, keys=[self._name, "resources", "storage_buckets", key.value]
+            )
 
 
 """
@@ -82,8 +150,10 @@ class Config(ABC, LoggingBase):
 
     _region: str
 
-    def __init__(self):
+    def __init__(self, name: str):
         super().__init__()
+        self._region = ""
+        self._name = name
 
     @property
     def region(self) -> str:
@@ -101,7 +171,12 @@ class Config(ABC, LoggingBase):
 
     @staticmethod
     @abstractmethod
-    def deserialize(config: dict, cache: Cache, handlers: LoggingHandlers) -> "Config":
+    def initialize(cfg: Config, dct: dict):
+        cfg._region = dct["region"]
+
+    @staticmethod
+    @abstractmethod
+    def deserialize(config: dict, cache: Cache, handlers: LoggingHandlers) -> Config:
         from sebs.local.config import LocalConfig
 
         name = config["name"]
@@ -128,8 +203,8 @@ class Config(ABC, LoggingBase):
 
     @abstractmethod
     def serialize(self) -> dict:
-        pass
+        return {"name": self._name, "region": self._region}
 
     @abstractmethod
     def update_cache(self, cache: Cache):
-        pass
+        cache.update_config(val=self.region, keys=[self._name, "region"])

--- a/sebs/faas/config.py
+++ b/sebs/faas/config.py
@@ -4,7 +4,6 @@ from abc import ABC
 from abc import abstractmethod
 from enum import Enum
 from typing import Dict, Optional
-import uuid
 
 from sebs.cache import Cache
 from sebs.utils import has_platform, LoggingBase, LoggingHandlers
@@ -72,15 +71,20 @@ class Resources(ABC, LoggingBase):
         super().__init__()
         self._name = name
         self._buckets: Dict[Resources.StorageBucketType, str] = {}
-        self._resources_id = ""
+        self._resources_id: Optional[str] = None
 
     @property
     def resources_id(self) -> str:
+        assert self._resources_id is not None
         return self._resources_id
 
     @resources_id.setter
     def resources_id(self, resources_id: str):
         self._resources_id = resources_id
+
+    @property
+    def has_resources_id(self) -> bool:
+        return self._resources_id is not None
 
     @property
     def region(self) -> str:
@@ -105,11 +109,7 @@ class Resources(ABC, LoggingBase):
 
         if "resources_id" in dct:
             res._resources_id = dct["resources_id"]
-        else:
-            res._resources_id = str(uuid.uuid1())[0:8]
-            res.logging.info(
-                f"Generating unique resource name for " f"the experiments: {res._resources_id}"
-            )
+
         if "storage_buckets" in dct:
             for key, value in dct["storage_buckets"].items():
                 res._buckets[Resources.StorageBucketType.deserialize(key)] = value

--- a/sebs/faas/config.py
+++ b/sebs/faas/config.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 from abc import ABC
 from abc import abstractmethod
-
 from enum import Enum
 from typing import Dict, Optional
 import uuid
@@ -101,6 +102,7 @@ class Resources(ABC, LoggingBase):
     @staticmethod
     @abstractmethod
     def initialize(res: Resources, dct: dict):
+
         if "resources_id" in dct:
             res._resources_id = dct["resources_id"]
         else:

--- a/sebs/faas/storage.py
+++ b/sebs/faas/storage.py
@@ -4,6 +4,7 @@ from abc import ABC
 from abc import abstractmethod
 from typing import List, Tuple
 
+from sebs.faas.config import Resources
 from sebs.cache import Cache
 from sebs.utils import LoggingBase
 
@@ -34,7 +35,9 @@ class PersistentStorage(ABC, LoggingBase):
     def region(self):
         return self._region
 
-    def __init__(self, region: str, cache_client: Cache, replace_existing: bool):
+    def __init__(
+        self, region: str, cache_client: Cache, resources: Resources, replace_existing: bool
+    ):
         super().__init__()
         self._cache_client = cache_client
         self.cached = False
@@ -43,6 +46,7 @@ class PersistentStorage(ABC, LoggingBase):
         self.input_buckets_files: List[List[str]] = []
         self._replace_existing = replace_existing
         self._region = region
+        self._cloud_resources = resources
 
     @property
     def input(self) -> List[str]:  # noqa: A003
@@ -57,7 +61,7 @@ class PersistentStorage(ABC, LoggingBase):
         pass
 
     @abstractmethod
-    def _create_bucket(self, name: str, buckets: List[str] = []):
+    def _create_bucket(self, name: str, buckets: List[str] = [], randomize_name: bool = False):
         pass
 
     """
@@ -213,6 +217,21 @@ class PersistentStorage(ABC, LoggingBase):
                 self._create_bucket(self.correct_name("{}-{}-output".format(benchmark, i)), buckets)
             )
         self.save_storage(benchmark)
+
+    def experiments_bucket(self) -> str:
+
+        bucket_type = Resources.StorageBucketType.EXPERIMENTS
+        bucket = self._cloud_resources.get_storage_bucket(bucket_type)
+        if bucket is None:
+            self.logging.info("Initialize a new bucket for experiments results")
+            # FIXME: detect existing vucket
+            bucket = self._create_bucket(
+                self.correct_name(self._cloud_resources.get_storage_bucket_name(bucket_type)),
+                randomize_name=False,
+            )
+            self._cloud_resources.set_storage_bucket(bucket_type, bucket)
+
+        return bucket
 
     """
         Implements a handy routine for uploading input data by benchmarks.

--- a/sebs/faas/storage.py
+++ b/sebs/faas/storage.py
@@ -164,7 +164,10 @@ class PersistentStorage(ABC, LoggingBase):
 
             for prefix in self.input_prefixes:
                 self.input_prefixes_files.append(
-                    self.list_bucket(self.benchmarks_bucket(), self.input_prefixes[-1])
+                    self.list_bucket(
+                        self.get_bucket(Resources.StorageBucketType.BENCHMARKS),
+                        self.input_prefixes[-1],
+                    )
                 )
 
         self._cache_client.update_storage(
@@ -228,27 +231,16 @@ class PersistentStorage(ABC, LoggingBase):
     #    )
     # self.save_storage(benchmark)
 
-    def benchmarks_bucket(self) -> str:
+    def get_bucket(self, bucket_type: Resources.StorageBucketType) -> str:
 
-        bucket_type = Resources.StorageBucketType.BENCHMARKS
         bucket = self._cloud_resources.get_storage_bucket(bucket_type)
         if bucket is None:
-            self.logging.info("Initialize a new bucket for benchmarks results")
-            bucket = self._create_bucket(
-                self.correct_name(self._cloud_resources.get_storage_bucket_name(bucket_type)),
-                randomize_name=False,
-            )
-            self._cloud_resources.set_storage_bucket(bucket_type, bucket)
-
-        return bucket
-
-    def experiments_bucket(self) -> str:
-
-        bucket_type = Resources.StorageBucketType.EXPERIMENTS
-        bucket = self._cloud_resources.get_storage_bucket(bucket_type)
-        if bucket is None:
-            self.logging.info("Initialize a new bucket for experiments results")
-            # FIXME: detect existing vucket
+            description = {
+                Resources.StorageBucketType.BENCHMARKS: "benchmarks",
+                Resources.StorageBucketType.EXPERIMENTS: "experiment results",
+                Resources.StorageBucketType.DEPLOYMENT: "code deployment",
+            }
+            self.logging.info(f"Initialize a new bucket for {description[bucket_type]}")
             bucket = self._create_bucket(
                 self.correct_name(self._cloud_resources.get_storage_bucket_name(bucket_type)),
                 randomize_name=False,

--- a/sebs/faas/storage.py
+++ b/sebs/faas/storage.py
@@ -177,7 +177,9 @@ class PersistentStorage(ABC, LoggingBase):
             self.cached = False
 
         # query buckets if the input prefixes changed, or the input is not up to date.
-        if self.cached is False or cached_storage["input_uploaded"] is False:
+        if cached_storage["input_uploaded"] is False:
+            self.cached = False
+        if self.cached is False:
 
             for prefix in self.input_prefixes:
                 self.input_prefixes_files.append(

--- a/sebs/faas/storage.py
+++ b/sebs/faas/storage.py
@@ -176,9 +176,10 @@ class PersistentStorage(ABC, LoggingBase):
         else:
             self.cached = False
 
-        # query buckets if the input prefixes changed, or the input is not up to date.
-        if cached_storage["input_uploaded"] is False:
+        if self.cached is True and cached_storage["input_uploaded"] is False:
             self.cached = False
+
+        # query buckets if the input prefixes changed, or the input is not up to date.
         if self.cached is False:
 
             for prefix in self.input_prefixes:

--- a/sebs/faas/storage.py
+++ b/sebs/faas/storage.py
@@ -257,11 +257,18 @@ class PersistentStorage(ABC, LoggingBase):
                 Resources.StorageBucketType.EXPERIMENTS: "experiment results",
                 Resources.StorageBucketType.DEPLOYMENT: "code deployment",
             }
-            self.logging.info(f"Initialize a new bucket for {description[bucket_type]}")
-            bucket = self._create_bucket(
-                self.correct_name(self._cloud_resources.get_storage_bucket_name(bucket_type)),
-                randomize_name=False,
-            )
+
+            name = self._cloud_resources.get_storage_bucket_name(bucket_type)
+
+            if not self.exists_bucket(name):
+                self.logging.info(f"Initialize a new bucket for {description[bucket_type]}")
+                bucket = self._create_bucket(
+                    self.correct_name(name),
+                    randomize_name=False,
+                )
+            else:
+                self.logging.info(f"Using existing bucket {name} for {description[bucket_type]}")
+                bucket = name
             self._cloud_resources.set_storage_bucket(bucket_type, bucket)
 
         return bucket

--- a/sebs/faas/storage.py
+++ b/sebs/faas/storage.py
@@ -41,80 +41,30 @@ class PersistentStorage(ABC, LoggingBase):
         super().__init__()
         self._cache_client = cache_client
         self.cached = False
-        self.input_buckets: List[str] = []
-        self.output_buckets: List[str] = []
-        self.input_buckets_files: List[List[str]] = []
+        self._input_prefixes: List[str] = []
+        self._output_prefixes: List[str] = []
+        self.input_prefixes_files: List[List[str]] = []
         self._replace_existing = replace_existing
         self._region = region
         self._cloud_resources = resources
 
     @property
-    def input(self) -> List[str]:  # noqa: A003
-        return self.input_buckets
+    def input_prefixes(self) -> List[str]:
+        return self._input_prefixes
 
     @property
-    def output(self) -> List[str]:
-        return self.output_buckets
+    def output_prefixes(self) -> List[str]:
+        return self._output_prefixes
 
     @abstractmethod
     def correct_name(self, name: str) -> str:
         pass
 
     @abstractmethod
-    def _create_bucket(self, name: str, buckets: List[str] = [], randomize_name: bool = False):
+    def _create_bucket(
+        self, name: str, buckets: List[str] = [], randomize_name: bool = False
+    ) -> str:
         pass
-
-    """
-        Some cloud systems might require additional suffixes to be
-        added to a bucket name.
-        For example, on AWS all bucket names are globally unique.
-        Thus, we need to add region as a suffix.
-
-        :return: suffix, might be empty
-    """
-
-    def _bucket_name_suffix(self) -> str:
-        return ""
-
-    def add_bucket(self, name: str, suffix: str, buckets: List[str]) -> Tuple[str, int]:
-
-        cloud_suffix = self._bucket_name_suffix()
-        if cloud_suffix:
-            name = self.correct_name(f"{name}-{len(buckets)}-{cloud_suffix}-{suffix}")
-        else:
-            name = self.correct_name(f"{name}-{len(buckets)}-{suffix}")
-        # there's cached bucket we could use
-        for idx, bucket in enumerate(buckets):
-            if name in bucket:
-                return bucket, idx
-        bucket_name = self._create_bucket(name)
-        buckets.append(bucket_name)
-        return bucket_name, len(buckets) - 1
-
-    """
-        Add an input bucket or retrieve an existing one.
-        Bucket name format: name-idx-input
-
-        :param name: bucket name
-        :param cache: use cache storage for buckets when true
-        :return: bucket name and index
-    """
-
-    def add_input_bucket(self, name: str) -> Tuple[str, int]:
-        return self.add_bucket(name, "input", self.input_buckets)
-
-    """
-        Add an input bucket or retrieve an existing one.
-        Bucket name format: name-idx-suffix
-
-        :param name: bucket name
-        :param suffix: bucket name suffix
-        :param cache: use cache storage for buckets when true
-        :return: bucket name and index
-    """
-
-    def add_output_bucket(self, name: str, suffix: str = "output") -> Tuple[str, int]:
-        return self.add_bucket(name, suffix, self.output_buckets)
 
     """
         Download a file from a bucket.
@@ -149,7 +99,7 @@ class PersistentStorage(ABC, LoggingBase):
     """
 
     @abstractmethod
-    def list_bucket(self, bucket_name: str) -> List[str]:
+    def list_bucket(self, bucket_name: str, prefix: str = "") -> List[str]:
         pass
 
     @abstractmethod
@@ -173,50 +123,124 @@ class PersistentStorage(ABC, LoggingBase):
         :param buckets: number of input and number of output buckets
     """
 
-    def allocate_buckets(self, benchmark: str, requested_buckets: Tuple[int, int]):
+    def benchmark_data(
+        self, benchmark: str, requested_buckets: Tuple[int, int]
+    ) -> Tuple[List[str], List[str]]:
 
-        # Load cached information
-        cached_buckets = self.cache_client.get_storage_config(self.deployment_name(), benchmark)
-        if cached_buckets:
-            cache_valid = True
-            for bucket in [
-                *cached_buckets["buckets"]["input"],
-                *cached_buckets["buckets"]["output"],
-            ]:
-                if not self.exists_bucket(bucket):
-                    cache_valid = False
-                    self.logging.info(f"Cached storage buckets {bucket} does not exist.")
-                    break
-
-            if cache_valid:
-                self.input_buckets = cached_buckets["buckets"]["input"]
-                for bucket in self.input_buckets:
-                    self.input_buckets_files.append(self.list_bucket(bucket))
-                self.output_buckets = cached_buckets["buckets"]["output"]
-                # for bucket in self.output_buckets:
-                #    self.clean_bucket(bucket)
-                self.cached = True
-                self.logging.info(
-                    "Using cached storage input buckets {}".format(self.input_buckets)
-                )
-                self.logging.info(
-                    "Using cached storage output buckets {}".format(self.output_buckets)
-                )
-                return
-            else:
-                self.logging.info("Cached storage buckets are no longer valid, creating new ones.")
-
-        buckets = self.list_buckets(self.correct_name(benchmark))
+        """
+        Add an input path inside benchmarks bucket.
+        Bucket name format: name-idx-input
+        """
         for i in range(0, requested_buckets[0]):
-            self.input_buckets.append(
-                self._create_bucket(self.correct_name("{}-{}-input".format(benchmark, i)), buckets)
-            )
-            self.input_buckets_files.append(self.list_bucket(self.input_buckets[-1]))
+            self.input_prefixes.append("{}-{}-input".format(benchmark, i))
+
+        """
+            Add an input path inside benchmarks bucket.
+            Bucket name format: name-idx-output
+        """
         for i in range(0, requested_buckets[1]):
-            self.output_buckets.append(
-                self._create_bucket(self.correct_name("{}-{}-output".format(benchmark, i)), buckets)
+            self.output_prefixes.append("{}-{}-output".format(benchmark, i))
+
+        cached_storage = self.cache_client.get_storage_config(self.deployment_name(), benchmark)
+        self.cached = True
+
+        if cached_storage is None:
+            self.cached = False
+            return self.input_prefixes, self.output_prefixes
+
+        cached_storage = cached_storage["buckets"]
+
+        # verify the input is up to date
+        for prefix in self.input_prefixes:
+            if prefix not in cached_storage["input"]:
+                self.cached = False
+
+        for prefix in self.output_prefixes:
+            if prefix not in cached_storage["output"]:
+                self.cached = False
+
+        # query buckets if the input prefixes changed, or the input is not up to date.
+        if self.cached is False or cached_storage["input_uploaded"] is False:
+
+            for prefix in self.input_prefixes:
+                self.input_prefixes_files.append(
+                    self.list_bucket(self.benchmarks_bucket(), self.input_prefixes[-1])
+                )
+
+        self._cache_client.update_storage(
+            self.deployment_name(),
+            benchmark,
+            {
+                "buckets": {
+                    "input": self.input_prefixes,
+                    "output": self.output_prefixes,
+                    "input_uploaded": self.cached,
+                }
+            },
+        )
+
+        return self.input_prefixes, self.output_prefixes
+
+    # def allocate_buckets(self, benchmark: str, requested_buckets: Tuple[int, int]):
+
+    # benchmarks_bucket = self.benchmarks_bucket()
+
+    # Load cached information
+    # cached_buckets = self.cache_client.get_storage_config(self.deployment_name(), benchmark)
+    # if cached_buckets:
+    #    cache_valid = True
+    #    for bucket in [
+    #        *cached_buckets["buckets"]["input"],
+    #        *cached_buckets["buckets"]["output"],
+    #    ]:
+    #        if not self.exists_bucket(bucket):
+    #            cache_valid = False
+    #            self.logging.info(f"Cached storage buckets {bucket} does not exist.")
+    #            break
+
+    #    if cache_valid:
+    #        self.input_buckets = cached_buckets["buckets"]["input"]
+    #        for bucket in self.input_buckets:
+    #            self.input_buckets_files.append(self.list_bucket(bucket))
+    #        self.output_buckets = cached_buckets["buckets"]["output"]
+    #        # for bucket in self.output_buckets:
+    #        #    self.clean_bucket(bucket)
+    #        self.cached = True
+    #        self.logging.info(
+    #            "Using cached storage input buckets {}".format(self.input_buckets)
+    #        )
+    #        self.logging.info(
+    #            "Using cached storage output buckets {}".format(self.output_buckets)
+    #        )
+    #        return
+    #    else:
+    #        self.logging.info("Cached storage buckets are no longer valid, creating new ones.")
+
+    # buckets = self.list_buckets(self.correct_name(benchmark))
+    # for i in range(0, requested_buckets[0]):
+    #    self.input_buckets.append(
+    #        self._create_bucket(self.correct_name("{}-{}-input".format(benchmark, i)), buckets)
+    #    )
+    #    self.input_buckets_files.append(self.list_bucket(self.input_buckets[-1]))
+    # for i in range(0, requested_buckets[1]):
+    #    self.output_buckets.append(
+    #        self._create_bucket(self.correct_name("{}-{}-output".format(benchmark, i)), buckets)
+    #    )
+    # self.save_storage(benchmark)
+
+    def benchmarks_bucket(self) -> str:
+
+        bucket_type = Resources.StorageBucketType.BENCHMARKS
+        bucket = self._cloud_resources.get_storage_bucket(bucket_type)
+        if bucket is None:
+            self.logging.info("Initialize a new bucket for benchmarks results")
+            bucket = self._create_bucket(
+                self.correct_name(self._cloud_resources.get_storage_bucket_name(bucket_type)),
+                randomize_name=False,
             )
-        self.save_storage(benchmark)
+            self._cloud_resources.set_storage_bucket(bucket_type, bucket)
+
+        return bucket
 
     def experiments_bucket(self) -> str:
 
@@ -246,17 +270,6 @@ class PersistentStorage(ABC, LoggingBase):
     @abstractmethod
     def uploader_func(self, bucket_idx: int, file: str, filepath: str) -> None:
         pass
-
-    """
-        Save benchmark input/output buckets to cache.
-    """
-
-    def save_storage(self, benchmark: str):
-        self.cache_client.update_storage(
-            self.deployment_name(),
-            benchmark,
-            {"buckets": {"input": self.input, "output": self.output}},
-        )
 
     """
         Download all files in a storage bucket.

--- a/sebs/faas/storage.py
+++ b/sebs/faas/storage.py
@@ -1,8 +1,9 @@
 import os
+import re
 
 from abc import ABC
 from abc import abstractmethod
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 from sebs.faas.config import Resources
 from sebs.cache import Cache
@@ -60,6 +61,18 @@ class PersistentStorage(ABC, LoggingBase):
     def correct_name(self, name: str) -> str:
         pass
 
+    def find_deployments(self) -> List[str]:
+
+        deployments = []
+        buckets = self.list_buckets()
+        for bucket in buckets:
+            # The benchmarks bucket must exist in every deployment.
+            deployment_search = re.match("sebs-benchmarks-(.*)", bucket)
+            if deployment_search:
+                deployments.append(deployment_search.group(1))
+
+        return deployments
+
     @abstractmethod
     def _create_bucket(
         self, name: str, buckets: List[str] = [], randomize_name: bool = False
@@ -103,7 +116,7 @@ class PersistentStorage(ABC, LoggingBase):
         pass
 
     @abstractmethod
-    def list_buckets(self, bucket_name: str) -> List[str]:
+    def list_buckets(self, bucket_name: Optional[str] = None) -> List[str]:
         pass
 
     @abstractmethod

--- a/sebs/faas/storage.py
+++ b/sebs/faas/storage.py
@@ -127,6 +127,10 @@ class PersistentStorage(ABC, LoggingBase):
     def clean_bucket(self, bucket_name: str):
         pass
 
+    @abstractmethod
+    def remove_bucket(self, bucket: str):
+        pass
+
     """
         Allocate a set of input/output buckets for the benchmark.
         The routine checks the cache first to verify that buckets have not

--- a/sebs/faas/system.py
+++ b/sebs/faas/system.py
@@ -9,6 +9,7 @@ import docker
 from sebs.benchmark import Benchmark
 from sebs.cache import Cache
 from sebs.config import SeBSConfig
+from sebs.faas.config import Resources
 from sebs.faas.function import Function, Trigger, ExecutionResult
 from sebs.faas.storage import PersistentStorage
 from sebs.utils import LoggingBase
@@ -100,9 +101,15 @@ class System(ABC, LoggingBase):
             self.logging.warning("Deployment resource IDs in the cloud: " f"{deployments}")
 
         # create
-        res_id = str(uuid.uuid1())[0:8]
+        res_id = ""
+        if select_prefix is not None:
+            res_id = f"{select_prefix}-{str(uuid.uuid1())[0:8]}"
+        else:
+            res_id = str(uuid.uuid1())[0:8]
         self.config.resources.resources_id = res_id
         self.logging.info(f"Generating unique resource name {res_id}")
+        # ensure that the bucket is created - this allocates the new resource
+        storage.get_bucket(Resources.StorageBucketType.BENCHMARKS)
 
     """
         Initialize the system. After the call the local or remot

--- a/sebs/faas/system.py
+++ b/sebs/faas/system.py
@@ -67,7 +67,17 @@ class System(ABC, LoggingBase):
     def function_type() -> "Type[Function]":
         pass
 
-    def initialize_resources(self, storage: PersistentStorage, select_prefix: Optional[str]):
+    def find_deployments(self) -> List[str]:
+
+        """
+            Default implementation that uses storage buckets.
+            data storage accounts.
+            This can be overriden, e.g., in Azure that looks for unique
+        """
+
+        return self.get_storage().find_deployments()
+
+    def initialize_resources(self, select_prefix: Optional[str]):
 
         # User provided resources or found in cache
         if self.config.resources.has_resources_id:
@@ -77,7 +87,7 @@ class System(ABC, LoggingBase):
             return
 
         # Now search for existing resources
-        deployments = storage.find_deployments()
+        deployments = self.find_deployments()
 
         # If a prefix is specified, we find the first matching resource ID
         if select_prefix is not None:
@@ -109,7 +119,7 @@ class System(ABC, LoggingBase):
         self.config.resources.resources_id = res_id
         self.logging.info(f"Generating unique resource name {res_id}")
         # ensure that the bucket is created - this allocates the new resource
-        storage.get_bucket(Resources.StorageBucketType.BENCHMARKS)
+        self.get_storage().get_bucket(Resources.StorageBucketType.BENCHMARKS)
 
     """
         Initialize the system. After the call the local or remot

--- a/sebs/faas/system.py
+++ b/sebs/faas/system.py
@@ -70,9 +70,9 @@ class System(ABC, LoggingBase):
     def find_deployments(self) -> List[str]:
 
         """
-            Default implementation that uses storage buckets.
-            data storage accounts.
-            This can be overriden, e.g., in Azure that looks for unique
+        Default implementation that uses storage buckets.
+        data storage accounts.
+        This can be overriden, e.g., in Azure that looks for unique
         """
 
         return self.get_storage().find_deployments()
@@ -141,7 +141,7 @@ class System(ABC, LoggingBase):
     """
 
     @abstractmethod
-    def get_storage(self, replace_existing: bool) -> PersistentStorage:
+    def get_storage(self, replace_existing: bool = False) -> PersistentStorage:
         pass
 
     """

--- a/sebs/faas/system.py
+++ b/sebs/faas/system.py
@@ -129,7 +129,7 @@ class System(ABC, LoggingBase):
         :param config: systems-specific parameters
     """
 
-    def initialize(self, config: Dict[str, str] = {}):
+    def initialize(self, config: Dict[str, str] = {}, resource_prefix: Optional[str] = None):
         pass
 
     """

--- a/sebs/gcp/config.py
+++ b/sebs/gcp/config.py
@@ -107,18 +107,20 @@ class GCPCredentials(Credentials):
 
 class GCPResources(Resources):
     def __init__(self):
-        super().__init__()
+        super().__init__(name="gcp")
 
     @staticmethod
     def initialize(res: Resources, dct: dict):
-        pass
+        ret = cast(GCPResources, res)
+        super(GCPResources, GCPResources).initialize(ret, dct)
+        return ret
 
     """
         Serialize to JSON for storage in cache.
     """
 
     def serialize(self) -> dict:
-        return {}
+        return super().serialize()
 
     @staticmethod
     def deserialize(config: dict, cache: Cache, handlers: LoggingHandlers) -> "Resources":
@@ -130,13 +132,20 @@ class GCPResources(Resources):
             ret.logging_handlers = handlers
             ret.logging.info("Using cached resources for GCP")
         else:
-            GCPResources.initialize(ret, config["resources"])
-            ret.logging_handlers = handlers
-            ret.logging.info("No cached resources for GCP found, using user configuration.")
+
+            if "resources" in config:
+                GCPResources.initialize(ret, config["resources"])
+                ret.logging_handlers = handlers
+                ret.logging.info("No cached resources for GCP found, using user configuration.")
+            else:
+                GCPResources.initialize(ret, {})
+                ret.logging_handlers = handlers
+                ret.logging.info("No resources for GCP found, initialize!")
+
         return ret
 
     def update_cache(self, cache: Cache):
-        pass
+        super().update_cache(cache)
 
 
 """
@@ -150,7 +159,7 @@ class GCPConfig(Config):
     _project_name: str
 
     def __init__(self, credentials: GCPCredentials, resources: GCPResources):
-        super().__init__()
+        super().__init__(name="gcp")
         self._credentials = credentials
         self._resources = resources
 

--- a/sebs/gcp/config.py
+++ b/sebs/gcp/config.py
@@ -110,8 +110,8 @@ class GCPResources(Resources):
         super().__init__()
 
     @staticmethod
-    def initialize(dct: dict) -> Resources:
-        return GCPResources()
+    def initialize(res: Resources, dct: dict):
+        pass
 
     """
         Serialize to JSON for storage in cache.
@@ -122,14 +122,15 @@ class GCPResources(Resources):
 
     @staticmethod
     def deserialize(config: dict, cache: Cache, handlers: LoggingHandlers) -> "Resources":
+
         cached_config = cache.get_config("gcp")
-        ret: GCPResources
+        ret = GCPResources()
         if cached_config and "resources" in cached_config:
-            ret = cast(GCPResources, GCPResources.initialize(cached_config["resources"]))
+            GCPResources.initialize(ret, cached_config["resources"])
             ret.logging_handlers = handlers
             ret.logging.info("Using cached resources for GCP")
         else:
-            ret = cast(GCPResources, GCPResources.initialize(config))
+            GCPResources.initialize(ret, config["resources"])
             ret.logging_handlers = handlers
             ret.logging.info("No cached resources for GCP found, using user configuration.")
         return ret

--- a/sebs/gcp/function.py
+++ b/sebs/gcp/function.py
@@ -1,5 +1,6 @@
 from typing import cast, Optional
 
+from sebs.faas.config import Resources
 from sebs.faas.function import Function, FunctionConfig
 from sebs.gcp.storage import GCPStorage
 
@@ -50,5 +51,5 @@ class GCPFunction(Function):
 
     def code_bucket(self, benchmark: str, storage_client: GCPStorage):
         if not self.bucket:
-            self.bucket, idx = storage_client.add_input_bucket(benchmark)
+            self.bucket = storage_client.get_bucket(Resources.StorageBucketType.DEPLOYMENT)
         return self.bucket

--- a/sebs/gcp/gcp.py
+++ b/sebs/gcp/gcp.py
@@ -18,6 +18,7 @@ from sebs.config import SeBSConfig
 from sebs.benchmark import Benchmark
 from ..faas.function import Function, FunctionConfig, Trigger
 from .storage import PersistentStorage
+from sebs.faas.config import Resources
 from ..faas.system import System
 from sebs.gcp.config import GCPConfig
 from sebs.gcp.storage import GCPStorage
@@ -71,9 +72,10 @@ class GCP(System):
         :param config: systems-specific parameters
     """
 
-    def initialize(self, config: Dict[str, str] = {}):
+    def initialize(self, config: Dict[str, str] = {}, resource_prefix: Optional[str] = None):
         self.function_client = build("cloudfunctions", "v1", cache_discovery=False)
         self.get_storage()
+        self.initialize_resources(select_prefix=resource_prefix)
 
     def get_function_client(self):
         return self.function_client
@@ -204,8 +206,10 @@ class GCP(System):
         function_cfg = FunctionConfig.from_benchmark(code_package)
 
         code_package_name = cast(str, os.path.basename(package))
-        code_bucket, idx = storage_client.add_input_bucket(benchmark)
-        storage_client.upload(code_bucket, package, code_package_name)
+        code_bucket = storage_client.get_bucket(Resources.StorageBucketType.DEPLOYMENT)
+        code_prefix = os.path.join(benchmark, code_package_name)
+        storage_client.upload(code_bucket, package, code_prefix)
+
         self.logging.info("Uploading function {} code to {}".format(func_name, code_bucket))
 
         full_func_name = GCP.get_full_function_name(project_name, location, func_name)
@@ -230,7 +234,7 @@ class GCP(System):
                         "timeout": str(timeout) + "s",
                         "httpsTrigger": {},
                         "ingressSettings": "ALLOW_ALL",
-                        "sourceArchiveUrl": "gs://" + code_bucket + "/" + code_package_name,
+                        "sourceArchiveUrl": "gs://" + code_bucket + "/" + code_prefix,
                     },
                 )
             )

--- a/sebs/gcp/gcp.py
+++ b/sebs/gcp/gcp.py
@@ -93,7 +93,9 @@ class GCP(System):
         buckets=None,
     ) -> PersistentStorage:
         if not self.storage:
-            self.storage = GCPStorage(self.config.region, self.cache_client, replace_existing)
+            self.storage = GCPStorage(
+                self.config.region, self.cache_client, self.config.resources, replace_existing
+            )
             self.storage.logging_handlers = self.logging_handlers
         else:
             self.storage.replace_existing = replace_existing

--- a/sebs/gcp/storage.py
+++ b/sebs/gcp/storage.py
@@ -6,6 +6,7 @@ from google.cloud import storage as gcp_storage
 from google.api_core import exceptions
 
 from sebs.cache import Cache
+from sebs.faas.config import Resources
 from ..faas.storage import PersistentStorage
 
 
@@ -26,8 +27,10 @@ class GCPStorage(PersistentStorage):
     def replace_existing(self, val: bool):
         self._replace_existing = val
 
-    def __init__(self, region: str, cache_client: Cache, replace_existing: bool):
-        super().__init__(region, cache_client, replace_existing)
+    def __init__(
+        self, region: str, cache_client: Cache, resources: Resources, replace_existing: bool
+    ):
+        super().__init__(region, cache_client, resources, replace_existing)
         self.replace_existing = replace_existing
         self.client = gcp_storage.Client()
         self.cached = False
@@ -35,7 +38,7 @@ class GCPStorage(PersistentStorage):
     def correct_name(self, name: str) -> str:
         return name
 
-    def _create_bucket(self, name, buckets: List[str] = []):
+    def _create_bucket(self, name, buckets: List[str] = [], randomize_name: bool = False):
         found_bucket = False
         for bucket_name in buckets:
             if name in bucket_name:
@@ -43,8 +46,13 @@ class GCPStorage(PersistentStorage):
                 break
 
         if not found_bucket:
-            random_name = str(uuid.uuid4())[0:16]
-            bucket_name = "{}-{}".format(name, random_name).replace(".", "_")
+
+            if randomize_name:
+                random_name = str(uuid.uuid4())[0:16]
+                bucket_name = "{}-{}".format(name, random_name).replace(".", "_")
+            else:
+                bucket_name = name
+
             self.client.create_bucket(bucket_name)
             logging.info("Created bucket {}".format(bucket_name))
             return bucket_name

--- a/sebs/local/config.py
+++ b/sebs/local/config.py
@@ -49,7 +49,7 @@ class LocalResources(Resources):
 
 class LocalConfig(Config):
     def __init__(self):
-        super().__init__()
+        super().__init__(name="local")
         self._credentials = LocalCredentials()
         self._resources = LocalResources()
 

--- a/sebs/local/config.py
+++ b/sebs/local/config.py
@@ -23,7 +23,7 @@ class LocalCredentials(Credentials):
 
 class LocalResources(Resources):
     def __init__(self, storage_cfg: Optional[MinioConfig] = None):
-        super().__init__()
+        super().__init__(name="local")
         self._storage = storage_cfg
 
     @property
@@ -32,6 +32,10 @@ class LocalResources(Resources):
 
     def serialize(self) -> dict:
         return {}
+
+    @staticmethod
+    def initialize(res: Resources, cfg: dict):
+        pass
 
     @staticmethod
     def deserialize(config: dict, cache: Cache, handlers: LoggingHandlers) -> Resources:

--- a/sebs/local/deployment.py
+++ b/sebs/local/deployment.py
@@ -6,6 +6,7 @@ from typing import List, Optional
 
 from sebs.cache import Cache
 from sebs.local.function import LocalFunction
+from sebs.local.config import LocalResources
 from sebs.storage.minio import Minio, MinioConfig
 from sebs.utils import serialize, LoggingBase
 
@@ -54,6 +55,7 @@ class Deployment(LoggingBase):
 
             out.write(serialize(config))
 
+    # FIXME: do we still use it?
     @staticmethod
     def deserialize(path: str, cache_client: Cache) -> "Deployment":
         with open(path, "r") as in_f:
@@ -67,7 +69,7 @@ class Deployment(LoggingBase):
                 deployment._memory_measurement_pids = input_data["memory_measurements"]["pids"]
                 deployment._measurement_file = input_data["memory_measurements"]["file"]
             deployment._storage = Minio.deserialize(
-                MinioConfig.deserialize(input_data["storage"]), cache_client
+                MinioConfig.deserialize(input_data["storage"]), cache_client, LocalResources()
             )
             return deployment
 

--- a/sebs/local/local.py
+++ b/sebs/local/local.py
@@ -73,6 +73,8 @@ class Local(System):
         # disable external measurements
         self._measure_interval = -1
 
+        self.initialize_resources(select_prefix="local")
+
     """
         Create wrapper object for minio storage and fill buckets.
         Starts minio as a Docker instance, using always fresh buckets.

--- a/sebs/local/local.py
+++ b/sebs/local/local.py
@@ -91,7 +91,7 @@ class Local(System):
                     "The local deployment is missing the configuration of pre-allocated storage!"
                 )
             self.storage = Minio.deserialize(
-                self.config.resources.storage_config, self.cache_client
+                self.config.resources.storage_config, self.cache_client, self.config.resources
             )
             self.storage.logging_handlers = self.logging_handlers
         else:

--- a/sebs/openwhisk/config.py
+++ b/sebs/openwhisk/config.py
@@ -73,6 +73,11 @@ class OpenWhiskResources(Resources):
 
         cached_config = cache.get_config("openwhisk")
         ret = OpenWhiskResources()
+        if cached_config:
+            super(OpenWhiskResources, OpenWhiskResources).initialize(
+                ret, cached_config["resources"]
+            )
+
         # Check for new config - overrides but check if it's different
         if "docker_registry" in config:
 
@@ -134,6 +139,7 @@ class OpenWhiskResources(Resources):
         return ret
 
     def update_cache(self, cache: Cache):
+        super().update_cache(cache)
         cache.update_config(
             val=self.docker_registry, keys=["openwhisk", "resources", "docker", "registry"]
         )
@@ -148,6 +154,7 @@ class OpenWhiskResources(Resources):
 
     def serialize(self) -> dict:
         out: dict = {
+            **super().serialize(),
             "docker_registry": self.docker_registry,
             "docker_username": self.docker_username,
             "docker_password": self.docker_password,
@@ -163,7 +170,7 @@ class OpenWhiskConfig(Config):
     cache: Cache
 
     def __init__(self, config: dict, cache: Cache):
-        super().__init__()
+        super().__init__(name="openwhisk")
         self._credentials = OpenWhiskCredentials()
         self._resources = OpenWhiskResources()
         self.shutdownStorage = config["shutdownStorage"]

--- a/sebs/openwhisk/openwhisk.py
+++ b/sebs/openwhisk/openwhisk.py
@@ -57,7 +57,7 @@ class OpenWhisk(System):
                     "OpenWhisk is missing the configuration of pre-allocated storage!"
                 )
             self.storage = Minio.deserialize(
-                self.config.resources.storage_config, self.cache_client
+                self.config.resources.storage_config, self.cache_client, self.config.resources
             )
             self.storage.logging_handlers = self.logging_handlers
         else:

--- a/sebs/openwhisk/storage.py
+++ b/sebs/openwhisk/storage.py
@@ -1,5 +1,6 @@
 import docker
 
+from sebs.faas.config import Resources
 from sebs.storage import minio
 from sebs.storage.config import MinioConfig
 from sebs.cache import Cache
@@ -10,9 +11,17 @@ class Minio(minio.Minio):
     def deployment_name() -> str:
         return "openwhisk"
 
-    def __init__(self, docker_client: docker.client, cache_client: Cache, replace_existing: bool):
-        super().__init__(docker_client, cache_client, replace_existing)
+    def __init__(
+        self,
+        docker_client: docker.client,
+        cache_client: Cache,
+        res: Resources,
+        replace_existing: bool,
+    ):
+        super().__init__(docker_client, cache_client, res, replace_existing)
 
     @staticmethod
-    def deserialize(cached_config: MinioConfig, cache_client: Cache) -> "Minio":
-        return super(Minio, Minio)._deserialize(cached_config, cache_client, Minio)
+    def deserialize(
+        cached_config: MinioConfig, cache_client: Cache, resources: Resources
+    ) -> "Minio":
+        return super(Minio, Minio)._deserialize(cached_config, cache_client, resources, Minio)

--- a/sebs/regression.py
+++ b/sebs/regression.py
@@ -125,7 +125,8 @@ class AWSTestSequencePython(
                 self.client.output_dir, f"regression_{deployment_name}_{benchmark_name}.log"
             ),
         )
-        deployment_client.initialize()
+        with AWSTestSequencePython.lock:
+            deployment_client.initialize(resource_prefix="regression")
         return deployment_client
 
 
@@ -143,7 +144,8 @@ class AWSTestSequenceNodejs(
             cloud_config,
             logging_filename=f"regression_{deployment_name}_{benchmark_name}.log",
         )
-        deployment_client.initialize()
+        with AWSTestSequenceNodejs.lock:
+            deployment_client.initialize(resource_prefix="regression")
         return deployment_client
 
 
@@ -183,9 +185,9 @@ class AzureTestSequenceNodejs(
     def get_deployment(self, benchmark_name):
         deployment_name = "azure"
         assert cloud_config
-        with AzureTestSequencePython.lock:
-            if not AzureTestSequencePython.cfg:
-                AzureTestSequencePython.cfg = self.client.get_deployment_config(
+        with AzureTestSequenceNodejs.lock:
+            if not AzureTestSequenceNodejs.cfg:
+                AzureTestSequenceNodejs.cfg = self.client.get_deployment_config(
                     cloud_config,
                     logging_filename=f"regression_{deployment_name}_{benchmark_name}.log",
                 )

--- a/sebs/regression.py
+++ b/sebs/regression.py
@@ -168,7 +168,7 @@ class AzureTestSequencePython(
                     logging_filename=f"regression_{deployment_name}_{benchmark_name}.log",
                 )
 
-            if not hasattr(AzureTestSequencePython, 'cli'):
+            if not hasattr(AzureTestSequencePython, "cli"):
                 AzureTestSequencePython.cli = AzureCLI(
                     self.client.config, self.client.docker_client
                 )
@@ -200,7 +200,7 @@ class AzureTestSequenceNodejs(
                     logging_filename=f"regression_{deployment_name}_{benchmark_name}.log",
                 )
 
-            if not hasattr(AzureTestSequenceNodejs, 'cli'):
+            if not hasattr(AzureTestSequenceNodejs, "cli"):
                 AzureTestSequenceNodejs.cli = AzureCLI(
                     self.client.config, self.client.docker_client
                 )
@@ -407,9 +407,9 @@ def regression_suite(
         for failure in result.failures:
             print(f"- {failure}")
 
-    if hasattr(AzureTestSequenceNodejs, 'cli'):
+    if hasattr(AzureTestSequenceNodejs, "cli"):
         AzureTestSequenceNodejs.cli.shutdown()
-    if hasattr(AzureTestSequencePython, 'cli'):
+    if hasattr(AzureTestSequencePython, "cli"):
         AzureTestSequencePython.cli.shutdown()
 
     return not result.all_correct

--- a/sebs/regression.py
+++ b/sebs/regression.py
@@ -259,13 +259,14 @@ class OpenWhiskTestSequencePython(
     triggers=[Trigger.TriggerType.HTTP],
 ):
     def get_deployment(self, benchmark_name):
-        deployment_name = "gcp"
+        deployment_name = "openwhisk"
         assert cloud_config
         deployment_client = self.client.get_deployment(
             cloud_config,
             logging_filename=f"regression_{deployment_name}_{benchmark_name}.log",
         )
-        deployment_client.initialize()
+        with OpenWhiskTestSequencePython.lock:
+            deployment_client.initialize(resource_prefix="regression")
         return deployment_client
 
 
@@ -277,13 +278,14 @@ class OpenWhiskTestSequenceNodejs(
     triggers=[Trigger.TriggerType.HTTP],
 ):
     def get_deployment(self, benchmark_name):
-        deployment_name = "gcp"
+        deployment_name = "openwhisk"
         assert cloud_config
         deployment_client = self.client.get_deployment(
             cloud_config,
             logging_filename=f"regression_{deployment_name}_{benchmark_name}.log",
         )
-        deployment_client.initialize()
+        with OpenWhiskTestSequenceNodejs.lock:
+            deployment_client.initialize(resource_prefix="regression")
         return deployment_client
 
 

--- a/sebs/sebs.py
+++ b/sebs/sebs.py
@@ -187,7 +187,12 @@ class SeBS(LoggingBase):
 
     @staticmethod
     def get_storage_config_implementation(storage_type: types.Storage):
-        _storage_implementations = {types.Storage.MINIO: sebs.storage.config.MinioConfig}
+        _storage_implementations = {
+            types.Storage.MINIO: (
+                sebs.storage.config.MinioConfig,
+                sebs.storage.config.MinioResources,
+            )
+        }
         impl = _storage_implementations.get(storage_type)
         assert impl
         return impl

--- a/sebs/storage/config.py
+++ b/sebs/storage/config.py
@@ -1,8 +1,33 @@
-from typing import List
+from typing import cast, List
 
 from dataclasses import dataclass, field
 
 from sebs.cache import Cache
+from sebs.faas.config import Resources
+
+
+class MinioResources(Resources):
+    def __init__(self):
+        super().__init__(name="minio")
+
+    @staticmethod
+    def initialize(res: Resources, dct: dict):
+        ret = cast(MinioResources, res)
+        super(MinioResources, MinioResources).initialize(ret, dct)
+        return ret
+
+    def serialize(self) -> dict:
+        return super().serialize()
+
+    @staticmethod
+    def deserialize(config: dict) -> "Resources":  # type: ignore
+
+        ret = MinioResources()
+        MinioResources.initialize(ret, {})
+        return ret
+
+    def update_cache(self, cache: Cache):
+        super().update_cache(cache)
 
 
 @dataclass
@@ -12,19 +37,25 @@ class MinioConfig:
     access_key: str = ""
     secret_key: str = ""
     instance_id: str = ""
-    input_buckets: List[str] = field(default_factory=list)
     output_buckets: List[str] = field(default_factory=list)
+    input_buckets: List[str] = field(default_factory=lambda: [])
+    resources: MinioResources = field(default_factory=MinioResources)
     type: str = "minio"
 
     def update_cache(self, path: List[str], cache: Cache):
         for key in MinioConfig.__dataclass_fields__.keys():
             cache.update_config(val=getattr(self, key), keys=[*path, key])
+        self.resources.update_cache(cache)
 
     @staticmethod
     def deserialize(data: dict) -> "MinioConfig":
         keys = list(MinioConfig.__dataclass_fields__.keys())
         data = {k: v for k, v in data.items() if k in keys}
-        return MinioConfig(**data)
+
+        cfg = MinioConfig(**data)
+        cfg.resources = cast(MinioResources, MinioResources.deserialize(data["resources"]))
+
+        return cfg
 
     def serialize(self) -> dict:
-        return self.__dict__
+        return {**self.__dict__, "resources": self.resources.serialize()}

--- a/sebs/storage/config.py
+++ b/sebs/storage/config.py
@@ -39,13 +39,15 @@ class MinioConfig:
     instance_id: str = ""
     output_buckets: List[str] = field(default_factory=list)
     input_buckets: List[str] = field(default_factory=lambda: [])
-    resources: MinioResources = field(default_factory=MinioResources)
     type: str = "minio"
 
     def update_cache(self, path: List[str], cache: Cache):
+
         for key in MinioConfig.__dataclass_fields__.keys():
+            if key == "resources":
+                continue
             cache.update_config(val=getattr(self, key), keys=[*path, key])
-        self.resources.update_cache(cache)
+        # self.resources.update_cache(cache)
 
     @staticmethod
     def deserialize(data: dict) -> "MinioConfig":
@@ -53,9 +55,9 @@ class MinioConfig:
         data = {k: v for k, v in data.items() if k in keys}
 
         cfg = MinioConfig(**data)
-        cfg.resources = cast(MinioResources, MinioResources.deserialize(data["resources"]))
+        # cfg.resources = cast(MinioResources, MinioResources.deserialize(data["resources"]))
 
         return cfg
 
     def serialize(self) -> dict:
-        return {**self.__dict__, "resources": self.resources.serialize()}
+        return self.__dict__  # , "resources": self.resources.serialize()}

--- a/sebs/storage/minio.py
+++ b/sebs/storage/minio.py
@@ -205,7 +205,6 @@ class Minio(PersistentStorage):
         raise NotImplementedError()
 
     def exists_bucket(self, bucket_name: str) -> bool:
-        print(bucket_name)
         return self.connection.bucket_exists(bucket_name)
 
     def list_bucket(self, bucket_name: str, prefix: str = "") -> List[str]:

--- a/sebs/storage/minio.py
+++ b/sebs/storage/minio.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import os
 import secrets
@@ -163,7 +164,6 @@ class Minio(PersistentStorage):
 
     def uploader_func(self, path_idx, file, filepath):
         try:
-
             key = os.path.join(self.input_prefixes[path_idx], file)
             bucket_name = self.get_bucket(Resources.StorageBucketType.BENCHMARKS)
             self.connection.fput_object(bucket_name, key, filepath)
@@ -248,8 +248,8 @@ class Minio(PersistentStorage):
                 raise RuntimeError(f"Storage container {instance_id} does not exist!")
         else:
             obj._storage_container = None
-        obj._input_prefixes = cached_config.input_buckets
-        obj._output_prefixes = cached_config.output_buckets
+        obj._input_prefixes = copy.copy(cached_config.input_buckets)
+        obj._output_prefixes = copy.copy(cached_config.output_buckets)
         obj.configure_connection()
         return obj
 


### PR DESCRIPTION
This PR resolves the issue #185. We have used too many buckets, creating issues on systems such as AWS with a hard limit of 100 buckets per account. In this design, a single SeBS deployment will only create up to three buckets: one for all benchmarks, one for code deployment, and one for experiments.  On systems like Azure, we still use separate storage accounts for performance reasons.