### PR TITLE
Updated local instructions

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -85,7 +85,7 @@ instance. The `.deployment.local` object in the configuration JSON must contain 
 this automatically with a single command by using `jq`:
 
 ```
-jq --argfile file1 out_storage.json '.deployment.local.storage = $file1 ' config/example.json > config/local_deployment.json
+jq '.deployment.local.storage = input' config/example.json out_storage.json > config/local_deployment.json
 ```
 
 The output file will contain a JSON object that should look similar to this one:


### PR DESCRIPTION
replaced the deprecated --argfile command in jq with a different implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the usage guide to simplify the command for updating the storage field in the JSON configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->