### PR TITLE
Update linting process and repair CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,11 @@ jobs:
       - run:
           command: |
             . python-venv/bin/activate
+            black sebs --check --config .black.toml
+          name: Python code formatting with black
+      - run:
+          command: |
+            . python-venv/bin/activate
             flake8 sebs --config=.flake8.cfg --black-config=.black.toml --tee --output-file flake-reports
           name: Python code lint with flake8
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       - run:
           command: |
             . python-venv/bin/activate
-            flake8 sebs --config=.flake8.cfg --black-config=.black.toml --tee --output-file flake-reports
+            flake8 sebs --config=.flake8.cfg --tee --output-file flake-reports
           name: Python code lint with flake8
       - run:
           command: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,12 @@
 # SeBS specific
-regression*
+regression-cache*
+regression_*
+regression-output*
 *_code
 perf-cost*
 python-venv
-*cache*
+cache*
+!cache.py
 
 
 # Byte-compiled / optimized / DLL files

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ requests
 #linting
 flake8
 black==22.8.0
-flake8-black
 mypy
 types-pycurl
 types-requests

--- a/sebs/aws/aws.py
+++ b/sebs/aws/aws.py
@@ -390,17 +390,17 @@ class AWS(System):
 
     # @staticmethod
     def default_function_name(
-        self,code_package: Benchmark, resources: Optional[Resources] = None
+        self, code_package: Benchmark, resources: Optional[Resources] = None
     ) -> str:
         # Create function name
         resource_id = resources.resources_id if resources else self.config.resources.resources_id
         func_name = "sebs-{}-{}-{}-{}-{}".format(
-                resource_id,
-                code_package.benchmark,
-                code_package.language_name,
-                code_package.language_version,
-                code_package.architecture,
-            )
+            resource_id,
+            code_package.benchmark,
+            code_package.language_name,
+            code_package.language_version,
+            code_package.architecture,
+        )
         if code_package.container_deployment:
             func_name = f"{func_name}-docker"
         return AWS.format_function_name(func_name)

--- a/sebs/cache.py
+++ b/sebs/cache.py
@@ -35,7 +35,6 @@ def update_dict(cfg, val, keys):
 
 
 class Cache(LoggingBase):
-
     cached_config: Dict[str, str] = {}
     """
         Indicate that cloud offerings updated credentials or settings.
@@ -123,8 +122,12 @@ class Cache(LoggingBase):
     """
 
     def get_code_package(
-        self, deployment: str, benchmark: str, language: str,
-        language_version: str, architecture: str
+        self,
+        deployment: str,
+        benchmark: str,
+        language: str,
+        language_version: str,
+        architecture: str,
     ) -> Optional[Dict[str, Any]]:
         cfg = self.get_benchmark_config(deployment, benchmark)
 
@@ -135,8 +138,12 @@ class Cache(LoggingBase):
             return None
 
     def get_container(
-        self, deployment: str, benchmark: str, language: str,
-        language_version: str, architecture: str
+        self,
+        deployment: str,
+        benchmark: str,
+        language: str,
+        language_version: str,
+        architecture: str,
     ) -> Optional[Dict[str, Any]]:
         cfg = self.get_benchmark_config(deployment, benchmark)
 
@@ -201,8 +208,12 @@ class Cache(LoggingBase):
             package_type = "docker" if code_package.container_deployment else "package"
             # Check if cache directory for this deployment exist
             cached_dir = os.path.join(
-                benchmark_dir, deployment_name, language,
-                language_version, architecture, package_type
+                benchmark_dir,
+                deployment_name,
+                language,
+                language_version,
+                architecture,
+                package_type,
             )
 
             if not os.path.exists(cached_dir):
@@ -230,7 +241,6 @@ class Cache(LoggingBase):
 
                 key = f"{language_version}-{architecture}"
                 if code_package.container_deployment:
-
                     image = self.docker_client.images.get(code_package.container_uri)
                     language_config["image-uri"] = code_package.container_uri
                     language_config["image-id"] = image.id
@@ -238,9 +248,7 @@ class Cache(LoggingBase):
                     config = {
                         deployment_name: {
                             language: {
-                                "containers": {
-                                    key: language_config
-                                },
+                                "containers": {key: language_config},
                                 "code_package": {},
                                 "functions": {},
                             }
@@ -250,9 +258,7 @@ class Cache(LoggingBase):
                     config = {
                         deployment_name: {
                             language: {
-                                "code_package": {
-                                    key: language_config
-                                },
+                                "code_package": {key: language_config},
                                 "containers": {},
                                 "functions": {},
                             }
@@ -266,7 +272,6 @@ class Cache(LoggingBase):
                         if deployment_name in cached_config:
                             # language known, platform known, extend dictionary
                             if language in cached_config[deployment_name]:
-
                                 if code_package.container_deployment:
                                     cached_config[deployment_name][language]["containers"][
                                         key
@@ -309,12 +314,15 @@ class Cache(LoggingBase):
             package_type = "docker" if code_package.container_deployment else "package"
             # Check if cache directory for this deployment exist
             cached_dir = os.path.join(
-                benchmark_dir, deployment_name, language,
-                language_version, architecture, package_type
+                benchmark_dir,
+                deployment_name,
+                language,
+                language_version,
+                architecture,
+                package_type,
             )
 
             if os.path.exists(cached_dir):
-
                 # copy code
                 if os.path.isdir(code_package.code_location):
                     cached_location = os.path.join(cached_dir, "code")
@@ -339,22 +347,15 @@ class Cache(LoggingBase):
                     else:
                         main_key = "code_package"
 
-                    config[deployment_name][language][main_key][key]["date"][
-                        "modified"
-                    ] = date
-                    config[deployment_name][language][main_key][key][
-                        "hash"
-                    ] = code_package.hash
+                    config[deployment_name][language][main_key][key]["date"]["modified"] = date
+                    config[deployment_name][language][main_key][key]["hash"] = code_package.hash
                     config[deployment_name][language][main_key][key][
                         "size"
                     ] = code_package.code_size
 
                     if code_package.container_deployment:
-
                         image = self.docker_client.images.get(code_package.container_uri)
-                        config[deployment_name][language][main_key][key][
-                            "image-id"
-                        ] = image.id
+                        config[deployment_name][language][main_key][key]["image-id"] = image.id
                         config[deployment_name][language][main_key][key][
                             "image-uri"
                         ] = code_package.container_uri
@@ -416,7 +417,6 @@ class Cache(LoggingBase):
             cache_config = os.path.join(benchmark_dir, "config.json")
 
             if os.path.exists(cache_config):
-
                 with open(cache_config, "r") as fp:
                     cached_config = json.load(fp)
                     for deployment, cfg in cached_config.items():

--- a/sebs/cache.py
+++ b/sebs/cache.py
@@ -174,7 +174,8 @@ class Cache(LoggingBase):
 
         if self.ignore_storage or not os.path.exists(config_path):
             self.logging.debug(
-                f"Skipping storage update: ignore_storage={self.ignore_storage}, config exists={os.path.exists(config_path)} at {config_path}"
+                f"Skipping storage update: ignore_storage={self.ignore_storage}, "
+                "config exists={os.path.exists(config_path)} at {config_path}"
             )
             return
         with self._lock:

--- a/sebs/gcp/gcp.py
+++ b/sebs/gcp/gcp.py
@@ -105,16 +105,16 @@ class GCP(System):
 
     # @staticmethod
     def default_function_name(
-        self,code_package: Benchmark, resources: Optional[Resources] = None
+        self, code_package: Benchmark, resources: Optional[Resources] = None
     ) -> str:
         # Create function name
         resource_id = resources.resources_id if resources else self.config.resources.resources_id
         func_name = "sebs-{}-{}-{}-{}".format(
-                resource_id,
-                code_package.benchmark,
-                code_package.language_name,
-                code_package.language_version,
-            )
+            resource_id,
+            code_package.benchmark,
+            code_package.language_name,
+            code_package.language_version,
+        )
         return GCP.format_function_name(func_name)
 
     @staticmethod

--- a/sebs/openwhisk/openwhisk.py
+++ b/sebs/openwhisk/openwhisk.py
@@ -327,9 +327,10 @@ class OpenWhisk(System):
     ) -> str:
         resource_id = resources.resources_id if resources else self.config.resources.resources_id
         return (
-                f"sebs-{resource_id}-{code_package.benchmark}-"
-                f"{code_package.language_name}-{code_package.language_version}"
-            )
+            f"sebs-{resource_id}-{code_package.benchmark}-"
+            f"{code_package.language_name}-{code_package.language_version}"
+        )
+
     def enforce_cold_start(self, functions: List[Function], code_package: Benchmark):
         raise NotImplementedError()
 

--- a/sebs/regression.py
+++ b/sebs/regression.py
@@ -45,16 +45,14 @@ cloud_config: Optional[dict] = None
 
 class TestSequenceMeta(type):
     def __init__(
-        cls, name, bases, attrs, benchmarks, architectures,
-        deployments, deployment_name, triggers
+        cls, name, bases, attrs, benchmarks, architectures, deployments, deployment_name, triggers
     ):
         type.__init__(cls, name, bases, attrs)
         cls.deployment_name = deployment_name
         cls.triggers = triggers
 
     def __new__(
-        mcs, name, bases, dict, benchmarks, architectures,
-        deployments, deployment_name, triggers
+        mcs, name, bases, dict, benchmarks, architectures, deployments, deployment_name, triggers
     ):
         def gen_test(benchmark_name, architecture, deployment_type):
             def test(self):
@@ -158,7 +156,7 @@ class AWSTestSequencePython(
             cloud_config,
             logging_filename=os.path.join(
                 self.client.output_dir,
-                f"regression_{deployment_name}_{benchmark_name}_{architecture}.log"
+                f"regression_{deployment_name}_{benchmark_name}_{architecture}.log",
             ),
         )
 
@@ -183,7 +181,7 @@ class AWSTestSequenceNodejs(
             cloud_config,
             logging_filename=os.path.join(
                 self.client.output_dir,
-                f"regression_{deployment_name}_{benchmark_name}_{architecture}.log"
+                f"regression_{deployment_name}_{benchmark_name}_{architecture}.log",
             ),
         )
         with AWSTestSequenceNodejs.lock:
@@ -210,7 +208,7 @@ class AzureTestSequencePython(
                     cloud_config,
                     logging_filename=os.path.join(
                         self.client.output_dir,
-                        f"regression_{deployment_name}_{benchmark_name}_{architecture}.log"
+                        f"regression_{deployment_name}_{benchmark_name}_{architecture}.log",
                     ),
                 )
 
@@ -223,7 +221,7 @@ class AzureTestSequencePython(
                 cloud_config,
                 logging_filename=os.path.join(
                     self.client.output_dir,
-                    f"regression_{deployment_name}_{benchmark_name}_{architecture}.log"
+                    f"regression_{deployment_name}_{benchmark_name}_{architecture}.log",
                 ),
                 deployment_config=AzureTestSequencePython.cfg,
             )
@@ -260,7 +258,7 @@ class AzureTestSequenceNodejs(
                 cloud_config,
                 logging_filename=os.path.join(
                     self.client.output_dir,
-                    f"regression_{deployment_name}_{benchmark_name}_{architecture}.log"
+                    f"regression_{deployment_name}_{benchmark_name}_{architecture}.log",
                 ),
                 deployment_config=AzureTestSequencePython.cfg,
             )
@@ -285,7 +283,7 @@ class GCPTestSequencePython(
             cloud_config,
             logging_filename=os.path.join(
                 self.client.output_dir,
-                f"regression_{deployment_name}_{benchmark_name}_{architecture}.log"
+                f"regression_{deployment_name}_{benchmark_name}_{architecture}.log",
             ),
         )
         with GCPTestSequencePython.lock:
@@ -309,7 +307,7 @@ class GCPTestSequenceNodejs(
             cloud_config,
             logging_filename=os.path.join(
                 self.client.output_dir,
-                f"regression_{deployment_name}_{benchmark_name}_{architecture}.log"
+                f"regression_{deployment_name}_{benchmark_name}_{architecture}.log",
             ),
         )
         with GCPTestSequenceNodejs.lock:
@@ -333,7 +331,7 @@ class OpenWhiskTestSequencePython(
             cloud_config,
             logging_filename=os.path.join(
                 self.client.output_dir,
-                f"regression_{deployment_name}_{benchmark_name}_{architecture}.log"
+                f"regression_{deployment_name}_{benchmark_name}_{architecture}.log",
             ),
         )
         with OpenWhiskTestSequencePython.lock:
@@ -357,7 +355,7 @@ class OpenWhiskTestSequenceNodejs(
             cloud_config,
             logging_filename=os.path.join(
                 self.client.output_dir,
-                f"regression_{deployment_name}_{benchmark_name}_{architecture}.log"
+                f"regression_{deployment_name}_{benchmark_name}_{architecture}.log",
             ),
         )
         with OpenWhiskTestSequenceNodejs.lock:
@@ -470,8 +468,11 @@ def regression_suite(
 
             # Remove unsupported benchmarks
             if not filter_out_benchmarks(
-                test_name, test.deployment_name, language,  # type: ignore
-                language_version, architecture  # type: ignore
+                test_name,
+                test.deployment_name,  # type: ignore
+                language,  # type: ignore
+                language_version,
+                architecture,  # type: ignore
             ):
                 print(f"Skip test {test_name} - not supported.")
                 continue

--- a/tools/linting.py
+++ b/tools/linting.py
@@ -3,15 +3,20 @@
 import subprocess
 from sys import argv, exit
 
+
 def call(linter, source, args):
     return subprocess.call([linter, source] + args.split())
+
 
 arg = argv[1]
 print("Code formatting of with Black")
 ret = call("black", arg, "--config .black.toml")
 
+print("Check if Black has been applied correctly")
+ret = ret | call("black", arg, "--check --config .black.toml")
+
 print("flake8 linting")
-ret = ret | call("flake8", arg, "--config=.flake8.cfg --black-config=.black.toml")
+ret = ret | call("flake8", arg, "--config=.flake8.cfg")
 
 print("Check static typing")
 ret = ret | call("mypy", arg, "--config-file=.mypy.ini")


### PR DESCRIPTION
We drop `flake8-black` because it has not been updated in a long time, and it kept our CI permanently broken. We also fixed `.gitignore`, since we were not linting `cache.py` and `regression.py`. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Integrated an automated formatting check with the Black linter into the continuous integration process.
	- Updated configuration settings for managing ignored files and streamlining dependency management.
- **Style**
	- Applied multiple internal formatting and readability improvements to enhance code consistency and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->