### PR TITLE
Fix documentation and the blocking bugs for local backend

### DIFF
--- a/benchmarks/000.microbenchmarks/010.sleep/config.json
+++ b/benchmarks/000.microbenchmarks/010.sleep/config.json
@@ -1,5 +1,6 @@
 {
   "timeout": 120,
   "memory": 128,
-  "languages": ["python", "nodejs"]
+  "languages": ["python", "nodejs"],
+  "modules": []
 }

--- a/benchmarks/000.microbenchmarks/010.sleep/input.py
+++ b/benchmarks/000.microbenchmarks/010.sleep/input.py
@@ -8,5 +8,5 @@ size_generators = {
 def buckets_count():
     return (0, 0)
 
-def generate_input(data_dir, size, input_buckets, output_buckets, upload_func):
+def generate_input(data_dir, size, benchmarks_bucket, input_paths, output_paths, upload_func, nosql_func):
     return { 'sleep': size_generators[size] }

--- a/benchmarks/000.microbenchmarks/020.network-benchmark/config.json
+++ b/benchmarks/000.microbenchmarks/020.network-benchmark/config.json
@@ -1,5 +1,6 @@
 {
   "timeout": 30,
   "memory": 128,
-  "languages": ["python"]
+  "languages": ["python"],
+  "modules": []
 }

--- a/benchmarks/000.microbenchmarks/020.network-benchmark/input.py
+++ b/benchmarks/000.microbenchmarks/020.network-benchmark/input.py
@@ -1,7 +1,11 @@
-
-
 def buckets_count():
-    return (0, 1)
+    return 0, 1
+
 
 def generate_input(data_dir, size, benchmarks_bucket, input_paths, output_paths, upload_func, nosql_func):
-    return {'output-bucket': output_buckets[0]}
+    return {
+        'bucket': {
+            'bucket': benchmarks_bucket,
+            'output': output_paths[0],
+        },
+    }

--- a/benchmarks/000.microbenchmarks/020.network-benchmark/input.py
+++ b/benchmarks/000.microbenchmarks/020.network-benchmark/input.py
@@ -3,5 +3,5 @@
 def buckets_count():
     return (0, 1)
 
-def generate_input(data_dir, size, input_buckets, output_buckets, upload_func):
+def generate_input(data_dir, size, benchmarks_bucket, input_paths, output_paths, upload_func, nosql_func):
     return {'output-bucket': output_buckets[0]}

--- a/benchmarks/000.microbenchmarks/020.network-benchmark/python/function.py
+++ b/benchmarks/000.microbenchmarks/020.network-benchmark/python/function.py
@@ -1,5 +1,6 @@
 import csv
 import json
+import os.path
 import socket
 from datetime import datetime
 from time import sleep
@@ -12,7 +13,8 @@ def handler(event):
     address = event['server-address']
     port = event['server-port']
     repetitions = event['repetitions']
-    output_bucket = event.get('output-bucket')
+    output_bucket = event.get('bucket').get('bucket')
+    output_prefix = event.get('bucket').get('output')
     times = []
     i = 0
     socket.setdefaulttimeout(3)
@@ -50,6 +52,7 @@ def handler(event):
                 writer.writerow(row)
       
         client = storage.storage.get_instance()
-        key = client.upload(output_bucket, 'results-{}.csv'.format(request_id), '/tmp/data.csv')
+        filename = 'results-{}.csv'.format(request_id)
+        key = client.upload(output_bucket, os.path.join(output_prefix, filename), '/tmp/data.csv')
 
     return { 'result': key }

--- a/benchmarks/000.microbenchmarks/030.clock-synchronization/config.json
+++ b/benchmarks/000.microbenchmarks/030.clock-synchronization/config.json
@@ -1,5 +1,6 @@
 {
   "timeout": 30,
   "memory": 128,
-  "languages": ["python"]
+  "languages": ["python"],
+  "modules": []
 }

--- a/benchmarks/000.microbenchmarks/030.clock-synchronization/input.py
+++ b/benchmarks/000.microbenchmarks/030.clock-synchronization/input.py
@@ -1,7 +1,12 @@
 
 
 def buckets_count():
-    return (0, 1)
+    return 0, 1
 
 def generate_input(data_dir, size, benchmarks_bucket, input_paths, output_paths, upload_func, nosql_func):
-    return {'output-bucket': output_buckets[0]}
+    return {
+        'bucket': {
+            'bucket': benchmarks_bucket,
+            'output': output_paths[0],
+        },
+    }

--- a/benchmarks/000.microbenchmarks/030.clock-synchronization/input.py
+++ b/benchmarks/000.microbenchmarks/030.clock-synchronization/input.py
@@ -3,5 +3,5 @@
 def buckets_count():
     return (0, 1)
 
-def generate_input(data_dir, size, input_buckets, output_buckets, upload_func):
+def generate_input(data_dir, size, benchmarks_bucket, input_paths, output_paths, upload_func, nosql_func):
     return {'output-bucket': output_buckets[0]}

--- a/benchmarks/000.microbenchmarks/030.clock-synchronization/python/function.py
+++ b/benchmarks/000.microbenchmarks/030.clock-synchronization/python/function.py
@@ -1,5 +1,6 @@
 import csv
 import json
+import os
 import socket
 from datetime import datetime
 from time import sleep
@@ -12,7 +13,8 @@ def handler(event):
     address = event['server-address']
     port = event['server-port']
     repetitions = event['repetitions']
-    output_bucket = event.get('output-bucket')
+    output_bucket = event.get('bucket').get('bucket')
+    output_prefix = event.get('bucket').get('output')
     times = []
     print("Starting communication with {}:{}".format(address, port))
     i = 0
@@ -64,7 +66,8 @@ def handler(event):
                 writer.writerow(row)
       
         client = storage.storage.get_instance()
-        key = client.upload(output_bucket, 'results-{}.csv'.format(request_id), '/tmp/data.csv')
+        filename = 'results-{}.csv'.format(request_id)
+        key = client.upload(output_bucket, os.path.join(output_prefix, filename), '/tmp/data.csv')
     else:
         key = None
 

--- a/benchmarks/000.microbenchmarks/040.server-reply/config.json
+++ b/benchmarks/000.microbenchmarks/040.server-reply/config.json
@@ -1,5 +1,6 @@
 {
   "timeout": 120,
   "memory": 128,
-  "languages": ["python", "nodejs"]
+  "languages": ["python", "nodejs"],
+  "modules": []
 }

--- a/benchmarks/000.microbenchmarks/040.server-reply/input.py
+++ b/benchmarks/000.microbenchmarks/040.server-reply/input.py
@@ -8,5 +8,5 @@ size_generators = {
 def buckets_count():
     return (0, 0)
 
-def generate_input(data_dir, size, input_buckets, output_buckets, upload_func):
+def generate_input(data_dir, size, benchmarks_bucket, input_paths, output_paths, upload_func, nosql_func):
     return { 'sleep': size_generators[size] }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -84,8 +84,7 @@ instance. The `.deployment.local` object in the configuration JSON must contain 
 this automatically with a single command by using `jq`:
 
 ```bash
-jq '.deployment.local.storage = input' config/example.json out_storage.json | \
-jq '.experiments.architecture = "x64"' > config/local_deployment.json
+jq '.deployment.local.storage = input' config/example.json out_storage.json > config/local_deployment.json
 ```
 
 The output file will contain a JSON object that should look similar to this one:
@@ -136,7 +135,7 @@ The output file will contain a JSON object that should look similar to this one:
 To launch Docker containers, use the following command - this example launches benchmark `110.dynamic-html` with size `test`:
 
 ```bash
-./sebs.py local start 110.dynamic-html test out_benchmark.json --config config/local_deployment.json --deployments 1 --remove-containers
+./sebs.py local start 110.dynamic-html test out_benchmark.json --config config/local_deployment.json --deployments 1 --remove-containers --architecture=x64
 ```
 
 The output file `out_benchmark.json` will contain the information on containers deployed and the endpoints that can be used to invoke functions:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -71,11 +71,11 @@ In addition to the cloud deployment, we provide an opportunity to launch benchma
 This allows us to conduct debugging and a local characterization of the benchmarks.
 
 First, launch a storage instance. The command below is going to deploy a Docker container,
-map the container's port to port `9011` on host network, and write storage instance configuration
-to file `out_storage.json`
+map the container's port to port defined in the configuration on host network, and write storage 
+instance configuration to file `out_storage.json`
 
-```
-./sebs.py storage start minio --port 9011 --output-json out_storage.json
+```bash
+./sebs.py storage start all config/storage.json --output-json out_storage.json
 ```
 
 Then, we need to update the configuration of `local` deployment with information on the storage 
@@ -83,34 +83,60 @@ instance. The `.deployment.local` object in the configuration JSON must contain 
 `storage`, with the data provided in the `out_storage.json` file. Fortunately, we can achieve
 this automatically with a single command by using `jq`:
 
-```
-jq '.deployment.local.storage = input' config/example.json out_storage.json > config/local_deployment.json
+```bash
+jq '.deployment.local.storage = input' config/example.json out_storage.json | \
+jq '.experiments.architecture = "x64"' > config/local_deployment.json
 ```
 
 The output file will contain a JSON object that should look similar to this one:
 
 ```json
-"deployment": {
-  "name": "local",
-  "local": {
-    "storage": {
-      "address": "172.17.0.2:9000",
-      "mapped_port": 9011,
-      "access_key": "XXXXX",
-      "secret_key": "XXXXX",
-      "instance_id": "XXXXX",
-      "input_buckets": [],
-      "output_buckets": [],
-      "type": "minio"
-    }
+{
+  "deployment": {
+    "name": "local",
+    "local": {
+      "storage": {
+        "object": {
+          "type": "minio",
+          "minio": {
+            "address": "172.17.0.3:9000",
+            "mapped_port": 9011,
+            "access_key": "xxx",
+            "secret_key": "xxx",
+            "instance_id": "xxx",
+            "output_buckets": [],
+            "input_buckets": [],
+            "version": "xxx",
+            "data_volume": "minio-volume",
+            "type": "minio"
+          }
+        },
+        "nosql": {
+          "type": "scylladb",
+          "scylladb": {
+            "address": "172.17.0.4:8000",
+            "mapped_port": 9012,
+            "alternator_port": 8000,
+            "access_key": "xxx",
+            "secret_key": "xxx",
+            "instance_id": "xxx",
+            "region": "xxx",
+            "cpus": 1,
+            "memory": "xxx",
+            "version": "xxx",
+            "data_volume": "scylladb-volume"
+          }
+        }
+      }
+    },
   }
 }
 ```
 
 To launch Docker containers, use the following command - this example launches benchmark `110.dynamic-html` with size `test`:
 
-```
-./sebs.py local start 110.dynamic-html test out_benchmark.json --config config/local_deployment.json --deployments 1
+```bash
+./sebs.py local start 110.dynamic-html test out_benchmark.json --config config/local_deployment.json --deployments 1 --remove-containers
 ```
 
 The output file `out_benchmark.json` will contain the information on containers deployed and the endpoints that can be used to invoke functions:
@@ -142,18 +168,22 @@ The output file `out_benchmark.json` will contain the information on containers 
 
 In our example, we can use `curl` to invoke the function with provided input:
 
-```
-curl 172.17.0.3:9000 --request POST --data '{"random_len": 10,"username": "testname"}' --header 'Content-Type: application/json'
+```bash
+curl $(jq -rc ".functions[0].url" out_benchmark.json) \
+    --request POST \
+    --data $(jq -rc ".inputs[0]" out_benchmark.json) \
+    --header 'Content-Type: application/json'
 ```
 
 To stop containers, you can use the following command:
 
 ```
 ./sebs.py local stop out_benchmark.json
-./sebs.py storage stop out_storage.json
+./sebs.py storage stop all out_storage.json
 ```
 
-The stopped containers won't be automatically removed unless the option `--remove-containers` has been passed to the `start` command.
+Note: The stopped benchmark containers won't be automatically removed 
+unless the option `--remove-containers` has been passed to the `local start` command.
 
 #### Memory Measurements
 

--- a/sebs/benchmark.py
+++ b/sebs/benchmark.py
@@ -430,11 +430,10 @@ class Benchmark(LoggingBase):
             )
         else:
             repo_name = self._system_config.docker_repository()
-            image_name = "build.{deployment}.{language}.{runtime}-{version}".format(
+            image_name = "build.{deployment}.{language}.{runtime}".format(
                 deployment=self._deployment_name,
                 language=self.language_name,
                 runtime=self.language_version,
-                version=self._system_config.version(),
             )
             try:
                 self._docker_client.images.get(repo_name + ":" + image_name)

--- a/sebs/config.py
+++ b/sebs/config.py
@@ -46,9 +46,6 @@ class SeBSConfig:
     ) -> List[str]:
         languages = self._system_config.get(deployment_name, {}).get("languages", {})
         base_images = languages.get(language_name, {}).get("base_images", {})
-
-        if deployment_name == "local":
-            return list(base_images.keys())
         return list(base_images.get(architecture, {}).keys())
 
     def supported_architecture(self, deployment_name: str) -> List[str]:

--- a/sebs/experiments/perf_cost.py
+++ b/sebs/experiments/perf_cost.py
@@ -83,7 +83,7 @@ class PerfCost(Experiment):
         for memory in memory_sizes:
             self.logging.info(f"Begin experiment on memory size {memory}")
             self._function.config.memory = memory
-            self._deployment_client.update_function(self._function, self._benchmark)
+            self._deployment_client.update_function(self._function, self._benchmark, False, '')
             self._sebs_client.cache_client.update_function(self._function)
             self.run_configuration(settings, settings["repetitions"], suffix=str(memory))
 


### PR DESCRIPTION
This PR introduces serveral mini fixes to make the local backend runnable out-of-the-box again.

1. Added an empty "modules" entry to the configuration structure of microbenchmarks.
2. Supplemented unused parameters in the Python input interface of microbenchmarks.
3. Updated the _Local_ section in the usage documentation.
4. Removed the version segment from the Docker build image tag.
5. Fixed the format of the `basic_image` field in the configuration for the local backend.
6. Added missing parameters to the invocation to `update_function` of the `Local` system.

Closes #248.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an additional configuration option for module management in benchmark setups.

- **Documentation**
  - Updated commands and configuration details for storage, deployment, and container management, enhancing ease of use and clarity.

- **Refactor**
  - Standardized benchmark input handling with updated parameters and return structures.
  - Refined deployment operations, including simplified image naming and streamlined update processes.
  - Improved handling of output paths for benchmark result uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->