### PR TITLE
feat(aws): add support for Lambda Function URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,3 +240,4 @@ However, they can be missing some of the features from the `master` branch.
 * [Mahla Sharifi](https://github.com/mahlashrifi) - contributed support for Java benchmarks.
 * [Alexander Schlieper (ETH Zurich)](https://github.com/xSurus) - improved support for Java benchmarks.
 * [Laurin Jahns (ETH Zurich)](https://github.com/userlaurin) - support for language variants.
+* [Sharayu Rasal](https://github.com/Sharayu1418) - help with function URLs on AWS.

--- a/configs/cpp.json
+++ b/configs/cpp.json
@@ -54,7 +54,11 @@
     "name": "aws",
     "aws": {
       "region": "us-east-1",
-      "lambda-role": ""
+      "lambda-role": "",
+      "resources": {
+        "use-function-url": true,
+        "function-url-auth-type": "NONE"
+      }
     },
     "azure": {
       "region": "westeurope"

--- a/configs/example.json
+++ b/configs/example.json
@@ -46,7 +46,11 @@
     "name": "aws",
     "aws": {
       "region": "us-east-1",
-      "lambda-role": ""
+      "lambda-role": "",
+      "resources": {
+        "use-function-url": false,
+        "function-url-auth-type": "NONE"
+      }
     },
     "azure": {
       "region": "westeurope"

--- a/configs/example.json
+++ b/configs/example.json
@@ -48,7 +48,7 @@
       "region": "us-east-1",
       "lambda-role": "",
       "resources": {
-        "use-function-url": false,
+        "use-function-url": true,
         "function-url-auth-type": "NONE"
       }
     },

--- a/configs/java.json
+++ b/configs/java.json
@@ -46,7 +46,11 @@
     "name": "aws",
     "aws": {
       "region": "us-east-1",
-      "lambda-role": ""
+      "lambda-role": "",
+      "resources": {
+        "use-function-url": true,
+        "function-url-auth-type": "NONE"
+      }
     },
     "azure": {
       "region": "westeurope"

--- a/configs/nodejs.json
+++ b/configs/nodejs.json
@@ -54,7 +54,11 @@
     "name": "aws",
     "aws": {
       "region": "us-east-1",
-      "lambda-role": ""
+      "lambda-role": "",
+      "resources": {
+        "use-function-url": true,
+        "function-url-auth-type": "NONE"
+      }
     },
     "azure": {
       "region": "westeurope"

--- a/configs/python.json
+++ b/configs/python.json
@@ -54,7 +54,11 @@
     "name": "aws",
     "aws": {
       "region": "us-east-1",
-      "lambda-role": ""
+      "lambda-role": "",
+      "resources": {
+        "use-function-url": true,
+        "function-url-auth-type": "NONE"
+      }
     },
     "azure": {
       "region": "westeurope"

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -77,6 +77,33 @@ or in the JSON input configuration:
 }
 ```
 
+### Lambda Function URLs vs API Gateway
+
+SeBS supports two methods for HTTP-based function invocation on AWS Lambda:
+
+1. **Lambda Function URLs** (default) - Direct Lambda invocations.
+2. **API Gateway HTTP API** (optional) - Traditional approach using AWS API Gateway.
+
+SeBS used API Gateway to trigger Lambda functions. However, API Gateway has a hard timeout limit of 29 seconds, which can be restrictive for long-running benchmarks. To overcome this limitation and simplify the architecture, we added support for Lambda Function URLs, which allow direct invocation of Lambda functions without the need for API Gateway. Since we do not rely on more complex API management features, function URLs are now the default version.
+
+However, API gateway can still be used to benchmarking. The switch between both options is configured in the deployment settings:
+
+```json
+"deployment": {
+  "name": "aws",
+  "aws": {
+    "region": "us-east-1",
+    "resources": {
+      "use-function-url": true,
+      "function-url-auth-type": "NONE"
+    }
+  }
+}
+```
+
+> [!WARNING]
+> SeBS implements the "NONE" authentication mode for function URLs, making Lambda functions publicly accessible without any authentication.
+
 ## Azure Functions
 
 Azure provides a free tier for 12 months.
@@ -270,9 +297,8 @@ See the documentation on the
 and [OpenWhisk configuration](https://github.com/apache/openwhisk-deploy-kube/blob/master/docs/private-docker-registry.md)
 for details.
 
-**Warning**: this feature is experimental and has not been tested extensively.
-At the moment, it cannot be used on a `kind` cluster due to issues with
-Docker authorization on invoker nodes. [See the OpenWhisk issue for details](https://github.com/apache/openwhisk-deploy-kube/issues/721).
+> [!WARNING]
+> This feature is experimental and has not been tested extensively. At the moment, it cannot be used on a `kind` cluster due to issues with Docker authorization on invoker nodes. [See the OpenWhisk issue for details](https://github.com/apache/openwhisk-deploy-kube/issues/721).
 
 ### Code Deployment
 

--- a/sebs/aws/aws.py
+++ b/sebs/aws/aws.py
@@ -639,13 +639,6 @@ class AWS(System):
         except Exception:
             self.logging.error("Function {} does not exist!".format(func_name))
 
-    def delete_function_url(self, func_name: str) -> bool:
-        """
-        Delete the Function URL associated with a Lambda function.
-        Returns True if deleted successfully, False if it didn't exist.
-        """
-        return self.config.resources.delete_function_url(func_name, self.session)
-
     @staticmethod
     def parse_aws_report(
         log: str, requests: Union[ExecutionResult, Dict[str, ExecutionResult]]

--- a/sebs/aws/aws.py
+++ b/sebs/aws/aws.py
@@ -699,7 +699,7 @@ class AWS(System):
     def cleanup_resources(self, dry_run: bool = False) -> dict:
         """Delete allocated resources on AWS.
         Currently it deletes the following resources:
-        * Lambda functions and its HTTP API triggers.
+        * Lambda functions and its HTTP API/Function URL triggers.
         * CloudWatch log groups of the functions.
         * DynamoDB tables created for the benchmark.
         * S3 buckets and their content created for the benchmark.
@@ -724,6 +724,10 @@ class AWS(System):
         result["Lambda functions"] = self.cleanup_functions(dry_run)
 
         result["HTTP APIs"] = self.config.resources.cleanup_http_apis(
+            self.session, self.cache_client, dry_run
+        )
+
+        result["Function URLs"] = self.config.resources.cleanup_function_urls(
             self.session, self.cache_client, dry_run
         )
 
@@ -885,17 +889,15 @@ class AWS(System):
 
         function = cast(LambdaFunction, func)
 
+        trigger: Trigger
         if trigger_type == Trigger.TriggerType.HTTP:
-
             if self.config.resources.use_function_url:
                 # Use Lambda Function URL (no 29-second timeout limit)
                 func_url = self.config.resources.function_url(function, self.session)
                 trigger = FunctionURLTrigger(
                     func_url.url, func_url.function_name, func_url.auth_type
                 )
-                self.logging.info(
-                    f"Created Function URL trigger for {func.name} function."
-                )
+                self.logging.info(f"Created Function URL trigger for {func.name} function.")
             else:
                 # Use API Gateway (default, for backward compatibility)
                 api_name = "{}-http-api".format(function.name)

--- a/sebs/aws/aws.py
+++ b/sebs/aws/aws.py
@@ -869,7 +869,7 @@ class AWS(System):
             f"out of {results_count} invocations"
         )
 
-    def create_trigger(self, func: Function, trigger_type: Trigger.TriggerType) -> Trigger:
+    def create_trigger(self, function: Function, trigger_type: Trigger.TriggerType) -> Trigger:
         """Create a trigger for the specified function.
 
         Creates and configures a trigger based on the specified type. Currently
@@ -885,19 +885,22 @@ class AWS(System):
         Raises:
             RuntimeError: If trigger type is not supported
         """
-        from sebs.aws.triggers import HTTPTrigger, FunctionURLTrigger
+        from sebs.aws.triggers import HTTPTrigger, HTTPTriggerImplementation
 
-        function = cast(LambdaFunction, func)
+        function = cast(LambdaFunction, function)
 
         trigger: Trigger
         if trigger_type == Trigger.TriggerType.HTTP:
             if self.config.resources.use_function_url:
                 # Use Lambda Function URL (no 29-second timeout limit)
                 func_url = self.config.resources.function_url(function, self.session)
-                trigger = FunctionURLTrigger(
-                    func_url.url, func_url.function_name, func_url.auth_type
+                trigger = HTTPTrigger(
+                    url=func_url.url,
+                    implementation=HTTPTriggerImplementation.FUNCTION_URL,
+                    function_name=func_url.function_name,
+                    auth_type=func_url.auth_type,
                 )
-                self.logging.info(f"Created Function URL trigger for {func.name} function.")
+                self.logging.info(f"Created Function URL trigger for {function.name} function.")
             else:
                 # Use API Gateway (default, for backward compatibility)
                 api_name = "{}-http-api".format(function.name)
@@ -911,9 +914,13 @@ class AWS(System):
                     Principal="apigateway.amazonaws.com",
                     SourceArn=f"{http_api.arn}/*/*",
                 )
-                trigger = HTTPTrigger(http_api.endpoint, api_name)
+                trigger = HTTPTrigger(
+                    url=http_api.endpoint,
+                    implementation=HTTPTriggerImplementation.API_GATEWAY,
+                    api_id=api_name,
+                )
                 self.logging.info(
-                    f"Created HTTP API Gateway trigger for {func.name} function. "
+                    f"Created HTTP API Gateway trigger for {function.name} function. "
                     "Sleep 5 seconds to avoid cloud errors."
                 )
                 time.sleep(5)
@@ -921,7 +928,7 @@ class AWS(System):
             trigger.logging_handlers = self.logging_handlers
         elif trigger_type == Trigger.TriggerType.LIBRARY:
             # should already exist
-            return func.triggers(Trigger.TriggerType.LIBRARY)[0]
+            return function.triggers(Trigger.TriggerType.LIBRARY)[0]
         else:
             raise RuntimeError("Not supported!")
 

--- a/sebs/aws/aws.py
+++ b/sebs/aws/aws.py
@@ -639,6 +639,13 @@ class AWS(System):
         except Exception:
             self.logging.error("Function {} does not exist!".format(func_name))
 
+    def delete_function_url(self, func_name: str) -> bool:
+        """
+        Delete the Function URL associated with a Lambda function.
+        Returns True if deleted successfully, False if it didn't exist.
+        """
+        return self.config.resources.delete_function_url(func_name, self.session)
+
     @staticmethod
     def parse_aws_report(
         log: str, requests: Union[ExecutionResult, Dict[str, ExecutionResult]]
@@ -874,28 +881,41 @@ class AWS(System):
         Raises:
             RuntimeError: If trigger type is not supported
         """
-        from sebs.aws.triggers import HTTPTrigger
+        from sebs.aws.triggers import HTTPTrigger, FunctionURLTrigger
 
         function = cast(LambdaFunction, func)
 
         if trigger_type == Trigger.TriggerType.HTTP:
-            api_name = "{}-http-api".format(function.name)
-            http_api = self.config.resources.http_api(api_name, function, self.session)
-            # https://aws.amazon.com/blogs/compute/announcing-http-apis-for-amazon-api-gateway/
-            # but this is wrong - source arn must be {api-arn}/*/*
-            self.get_lambda_client().add_permission(
-                FunctionName=function.name,
-                StatementId=str(uuid.uuid1()),
-                Action="lambda:InvokeFunction",
-                Principal="apigateway.amazonaws.com",
-                SourceArn=f"{http_api.arn}/*/*",
-            )
-            trigger = HTTPTrigger(http_api.endpoint, api_name)
-            self.logging.info(
-                f"Created HTTP trigger for {func.name} function. "
-                "Sleep 5 seconds to avoid cloud errors."
-            )
-            time.sleep(5)
+
+            if self.config.resources.use_function_url:
+                # Use Lambda Function URL (no 29-second timeout limit)
+                func_url = self.config.resources.function_url(function, self.session)
+                trigger = FunctionURLTrigger(
+                    func_url.url, func_url.function_name, func_url.auth_type
+                )
+                self.logging.info(
+                    f"Created Function URL trigger for {func.name} function."
+                )
+            else:
+                # Use API Gateway (default, for backward compatibility)
+                api_name = "{}-http-api".format(function.name)
+                http_api = self.config.resources.http_api(api_name, function, self.session)
+                # https://aws.amazon.com/blogs/compute/announcing-http-apis-for-amazon-api-gateway/
+                # but this is wrong - source arn must be {api-arn}/*/*
+                self.get_lambda_client().add_permission(
+                    FunctionName=function.name,
+                    StatementId=str(uuid.uuid1()),
+                    Action="lambda:InvokeFunction",
+                    Principal="apigateway.amazonaws.com",
+                    SourceArn=f"{http_api.arn}/*/*",
+                )
+                trigger = HTTPTrigger(http_api.endpoint, api_name)
+                self.logging.info(
+                    f"Created HTTP API Gateway trigger for {func.name} function. "
+                    "Sleep 5 seconds to avoid cloud errors."
+                )
+                time.sleep(5)
+
             trigger.logging_handlers = self.logging_handlers
         elif trigger_type == Trigger.TriggerType.LIBRARY:
             # should already exist

--- a/sebs/aws/config.py
+++ b/sebs/aws/config.py
@@ -264,6 +264,37 @@ class AWSResources(Resources):
             out = {"arn": self.arn, "endpoint": self.endpoint}
             return out
 
+    class FunctionURL:
+        def __init__(self, url: str, function_name: str, auth_type: str = "NONE"):
+            self._url = url
+            self._function_name = function_name
+            self._auth_type = auth_type
+
+        @property
+        def url(self) -> str:
+            return self._url
+
+        @property
+        def function_name(self) -> str:
+            return self._function_name
+
+        @property
+        def auth_type(self) -> str:
+            return self._auth_type
+
+        @staticmethod
+        def deserialize(dct: dict) -> "AWSResources.FunctionURL":
+            return AWSResources.FunctionURL(
+                dct["url"], dct["function_name"], dct.get("auth_type", "NONE")
+            )
+
+        def serialize(self) -> dict:
+            return {
+                "url": self.url,
+                "function_name": self.function_name,
+                "auth_type": self.auth_type,
+            }
+
     def __init__(
         self,
         registry: Optional[str] = None,
@@ -284,6 +315,9 @@ class AWSResources(Resources):
         self._container_repository: Optional[str] = None
         self._lambda_role = ""
         self._http_apis: Dict[str, AWSResources.HTTPApi] = {}
+        self._function_urls: Dict[str, AWSResources.FunctionURL] = {}
+        self._use_function_url: bool = False
+        self._function_url_auth_type: str = "NONE"
 
     @staticmethod
     def typename() -> str:
@@ -329,6 +363,24 @@ class AWSResources(Resources):
             Optional[str]: ECR repository name
         """
         return self._container_repository
+
+    @property
+    def use_function_url(self) -> bool:
+        return self._use_function_url
+
+    @use_function_url.setter
+    def use_function_url(self, value: bool):
+        self._use_function_url = value
+
+    @property
+    def function_url_auth_type(self) -> str:
+        return self._function_url_auth_type
+
+    @function_url_auth_type.setter
+    def function_url_auth_type(self, value: str):
+        if value not in ("NONE", "AWS_IAM"):
+            raise ValueError("function_url_auth_type must be 'NONE' or 'AWS_IAM'")
+        self._function_url_auth_type = value
 
     def lambda_role(self, boto3_session: boto3.session.Session) -> str:
         """Get or create IAM role for Lambda execution.
@@ -494,6 +546,105 @@ class AWSResources(Resources):
                 self._http_apis.pop(api_name, None)
 
         return deleted
+
+    def function_url(
+        self, func: LambdaFunction, boto3_session: boto3.session.Session
+    ) -> "AWSResources.FunctionURL":
+        """
+        Create or retrieve a Lambda Function URL for the given function.
+        Function URLs provide a simpler alternative to API Gateway without the
+        29-second timeout limit.
+        """
+        cached_url = self._function_urls.get(func.name)
+        if cached_url:
+            self.logging.info(f"Using cached Function URL for {func.name}")
+            return cached_url
+
+        lambda_client = boto3_session.client(
+            service_name="lambda", region_name=cast(str, self._region)
+        )
+
+        try:
+            response = lambda_client.get_function_url_config(FunctionName=func.name)
+            self.logging.info(f"Using existing Function URL for {func.name}")
+            url = response["FunctionUrl"]
+            auth_type = response["AuthType"]
+        except lambda_client.exceptions.ResourceNotFoundException:
+            self.logging.info(f"Creating Function URL for {func.name}")
+
+            auth_type = self._function_url_auth_type
+
+            if auth_type == "NONE":
+                try:
+                    lambda_client.add_permission(
+                        FunctionName=func.name,
+                        StatementId="FunctionURLAllowPublicAccess",
+                        Action="lambda:InvokeFunctionUrl",
+                        Principal="*",
+                        FunctionUrlAuthType="NONE",
+                    )
+                except lambda_client.exceptions.ResourceConflictException:
+                    pass
+
+            retries = 0
+            while retries < 5:
+                try:
+                    response = lambda_client.create_function_url_config(
+                        FunctionName=func.name,
+                        AuthType=auth_type,
+                    )
+                    break
+                except lambda_client.exceptions.ResourceConflictException:
+                    response = lambda_client.get_function_url_config(
+                        FunctionName=func.name
+                    )
+                    break
+                except Exception as e:
+                    retries += 1
+                    if retries == 5:
+                        self.logging.error("Failed to create Function URL!")
+                        self.logging.error(e)
+                        raise RuntimeError("Failed to create Function URL!")
+                    else:
+                        self.logging.info("Function URL creation failed, retrying...")
+                        time.sleep(retries)
+
+            url = response["FunctionUrl"]
+
+        function_url_obj = AWSResources.FunctionURL(url, func.name, auth_type)
+        self._function_urls[func.name] = function_url_obj
+        return function_url_obj
+
+    def delete_function_url(
+        self, function_name: str, boto3_session: boto3.session.Session
+    ) -> bool:
+        """
+        Delete a Lambda Function URL for the given function.
+        Returns True if deleted successfully, False if it didn't exist.
+        """
+        lambda_client = boto3_session.client(
+            service_name="lambda", region_name=cast(str, self._region)
+        )
+
+        try:
+            lambda_client.delete_function_url_config(FunctionName=function_name)
+            self.logging.info(f"Deleted Function URL for {function_name}")
+
+            try:
+                lambda_client.remove_permission(
+                    FunctionName=function_name,
+                    StatementId="FunctionURLAllowPublicAccess",
+                )
+            except lambda_client.exceptions.ResourceNotFoundException:
+                pass
+
+            if function_name in self._function_urls:
+                del self._function_urls[function_name]
+
+            return True
+        except lambda_client.exceptions.ResourceNotFoundException:
+            self.logging.info(f"No Function URL found for {function_name}")
+            return False
 
     def check_ecr_repository_exists(
         self, ecr_client: ECRClient, repository_name: str
@@ -715,6 +866,13 @@ class AWSResources(Resources):
             for key, value in dct["http-apis"].items():
                 ret._http_apis[key] = AWSResources.HTTPApi.deserialize(value)
 
+        if "function-urls" in dct:
+            for key, value in dct["function-urls"].items():
+                ret._function_urls[key] = AWSResources.FunctionURL.deserialize(value)
+
+        ret._use_function_url = dct.get("use-function-url", False)
+        ret._function_url_auth_type = dct.get("function-url-auth-type", "NONE")
+
     def serialize(self) -> dict:
         """Serialize AWS resources to dictionary.
 
@@ -725,6 +883,11 @@ class AWSResources(Resources):
             **super().serialize(),
             "lambda-role": self._lambda_role,
             "http-apis": {key: value.serialize() for (key, value) in self._http_apis.items()},
+            "function-urls": {
+                key: value.serialize() for (key, value) in self._function_urls.items()
+            },
+            "use-function-url": self._use_function_url,
+            "function-url-auth-type": self._function_url_auth_type,
             "docker": {
                 "registry": self.docker_registry,
                 "username": self.docker_username,
@@ -753,6 +916,16 @@ class AWSResources(Resources):
         cache.update_config(val=self._lambda_role, keys=["aws", "resources", "lambda-role"])
         for name, api in self._http_apis.items():
             cache.update_config(val=api.serialize(), keys=["aws", "resources", "http-apis", name])
+        for name, func_url in self._function_urls.items():
+            cache.update_config(
+                val=func_url.serialize(), keys=["aws", "resources", "function-urls", name]
+            )
+        cache.update_config(
+            val=self._use_function_url, keys=["aws", "resources", "use-function-url"]
+        )
+        cache.update_config(
+            val=self._function_url_auth_type, keys=["aws", "resources", "function-url-auth-type"]
+        )
 
     @staticmethod
     def deserialize(config: dict, cache: Cache, handlers: LoggingHandlers) -> Resources:

--- a/sebs/aws/config.py
+++ b/sebs/aws/config.py
@@ -347,7 +347,7 @@ class AWSResources(Resources):
         self._lambda_role = ""
         self._http_apis: Dict[str, AWSResources.HTTPApi] = {}
         self._function_urls: Dict[str, AWSResources.FunctionURL] = {}
-        self._use_function_url: bool = False
+        self._use_function_url: bool = True
         self._function_url_auth_type: FunctionURLAuthType = FunctionURLAuthType.NONE
 
     @staticmethod
@@ -604,13 +604,13 @@ class AWSResources(Resources):
         dry_run_tag = "[DRY-RUN] " if dry_run else ""
 
         dict_copy = self._function_urls.copy()
-        for func_name, _ in dict_copy.items():
+        for func_name, func_url in dict_copy.items():
 
             self.logging.info(f"{dry_run_tag}Deleting Function URL for: {func_name}")
 
             if not dry_run:
                 self.delete_function_url(func_name, boto3_session)
-            deleted.append(func_name)
+            deleted.append(func_url.url)
 
         if not dry_run:
             for func_name in deleted:
@@ -985,7 +985,7 @@ class AWSResources(Resources):
             for key, value in dct["function-urls"].items():
                 ret._function_urls[key] = AWSResources.FunctionURL.deserialize(value)
 
-        ret._use_function_url = dct.get("use-function-url", False)
+        ret._use_function_url = dct.get("use-function-url", True)
         auth_type_str = dct.get("function-url-auth-type", "NONE")
         ret.function_url_auth_type = FunctionURLAuthType.from_string(auth_type_str)
 

--- a/sebs/aws/config.py
+++ b/sebs/aws/config.py
@@ -17,6 +17,7 @@ import base64
 import json
 import os
 import time
+from enum import Enum
 from typing import TYPE_CHECKING, cast, Dict, List, Optional, Tuple
 
 import boto3
@@ -28,6 +29,28 @@ from sebs.cache import Cache
 from sebs.faas.config import Config, Credentials, Resources
 from sebs.aws.function import LambdaFunction
 from sebs.utils import LoggingHandlers
+
+
+class FunctionURLAuthType(Enum):
+    """
+    Authentication types for AWS Lambda Function URLs.
+    - NONE: Public access, no authentication required
+    - AWS_IAM: Requires IAM authentication with SigV4 signing
+    """
+
+    NONE = "NONE"
+    AWS_IAM = "AWS_IAM"
+
+    @staticmethod
+    def from_string(value: str) -> "FunctionURLAuthType":
+        """Convert string to FunctionURLAuthType enum."""
+        try:
+            return FunctionURLAuthType(value)
+        except ValueError:
+            raise ValueError(
+                f"Invalid auth type '{value}'. Must be one of: "
+                f"{[e.value for e in FunctionURLAuthType]}"
+            )
 
 
 class AWSCredentials(Credentials):
@@ -265,7 +288,12 @@ class AWSResources(Resources):
             return out
 
     class FunctionURL:
-        def __init__(self, url: str, function_name: str, auth_type: str = "NONE"):
+        def __init__(
+            self,
+            url: str,
+            function_name: str,
+            auth_type: FunctionURLAuthType = FunctionURLAuthType.NONE,
+        ):
             self._url = url
             self._function_name = function_name
             self._auth_type = auth_type
@@ -279,20 +307,23 @@ class AWSResources(Resources):
             return self._function_name
 
         @property
-        def auth_type(self) -> str:
+        def auth_type(self) -> FunctionURLAuthType:
             return self._auth_type
 
         @staticmethod
         def deserialize(dct: dict) -> "AWSResources.FunctionURL":
+            auth_type_str = dct.get("auth_type", "NONE")
             return AWSResources.FunctionURL(
-                dct["url"], dct["function_name"], dct.get("auth_type", "NONE")
+                dct["url"],
+                dct["function_name"],
+                FunctionURLAuthType.from_string(auth_type_str),
             )
 
         def serialize(self) -> dict:
             return {
                 "url": self.url,
                 "function_name": self.function_name,
-                "auth_type": self.auth_type,
+                "auth_type": self.auth_type.value,
             }
 
     def __init__(
@@ -317,7 +348,7 @@ class AWSResources(Resources):
         self._http_apis: Dict[str, AWSResources.HTTPApi] = {}
         self._function_urls: Dict[str, AWSResources.FunctionURL] = {}
         self._use_function_url: bool = False
-        self._function_url_auth_type: str = "NONE"
+        self._function_url_auth_type: FunctionURLAuthType = FunctionURLAuthType.NONE
 
     @staticmethod
     def typename() -> str:
@@ -373,13 +404,15 @@ class AWSResources(Resources):
         self._use_function_url = value
 
     @property
-    def function_url_auth_type(self) -> str:
+    def function_url_auth_type(self) -> FunctionURLAuthType:
         return self._function_url_auth_type
 
     @function_url_auth_type.setter
-    def function_url_auth_type(self, value: str):
-        if value not in ("NONE", "AWS_IAM"):
-            raise ValueError("function_url_auth_type must be 'NONE' or 'AWS_IAM'")
+    def function_url_auth_type(self, value: FunctionURLAuthType):
+        if not isinstance(value, FunctionURLAuthType):
+            raise TypeError(
+                f"function_url_auth_type must be a FunctionURLAuthType enum, got {type(value)}"
+            )
         self._function_url_auth_type = value
 
     def lambda_role(self, boto3_session: boto3.session.Session) -> str:
@@ -560,6 +593,14 @@ class AWSResources(Resources):
             self.logging.info(f"Using cached Function URL for {func.name}")
             return cached_url
 
+        # Check for unsupported auth type before attempting to create
+        if self._function_url_auth_type == FunctionURLAuthType.AWS_IAM:
+            raise NotImplementedError(
+                "AWS_IAM authentication for Function URLs is not yet supported. "
+                "SigV4 request signing is required for AWS_IAM auth type. "
+                "Please use auth_type='NONE' or implement SigV4 signing."
+            )
+
         lambda_client = boto3_session.client(
             service_name="lambda", region_name=cast(str, self._region)
         )
@@ -568,13 +609,18 @@ class AWSResources(Resources):
             response = lambda_client.get_function_url_config(FunctionName=func.name)
             self.logging.info(f"Using existing Function URL for {func.name}")
             url = response["FunctionUrl"]
-            auth_type = response["AuthType"]
+            auth_type = FunctionURLAuthType.from_string(response["AuthType"])
         except lambda_client.exceptions.ResourceNotFoundException:
             self.logging.info(f"Creating Function URL for {func.name}")
 
             auth_type = self._function_url_auth_type
 
-            if auth_type == "NONE":
+            if auth_type == FunctionURLAuthType.NONE:
+                self.logging.warning(
+                    f"Creating Function URL with auth_type=NONE for {func.name}. "
+                    "WARNING: This function will have unrestricted public access. "
+                    "Anyone with the URL can invoke this function."
+                )
                 try:
                     lambda_client.add_permission(
                         FunctionName=func.name,
@@ -584,6 +630,10 @@ class AWSResources(Resources):
                         FunctionUrlAuthType="NONE",
                     )
                 except lambda_client.exceptions.ResourceConflictException:
+                    # Permission with this StatementId already exists on the function.
+                    # This can happen if the function was previously configured with
+                    # a Function URL that was deleted but the permission remained,
+                    # or if there's a concurrent creation attempt. Safe to ignore.
                     pass
 
             retries = 0
@@ -591,23 +641,31 @@ class AWSResources(Resources):
                 try:
                     response = lambda_client.create_function_url_config(
                         FunctionName=func.name,
-                        AuthType=auth_type,
+                        AuthType=auth_type.value,
                     )
                     break
                 except lambda_client.exceptions.ResourceConflictException:
+                    # Function URL already exists - can happen if a concurrent process
+                    # created it between our check and create, or if there was a race
+                    # condition. Retrieve the existing configuration instead.
                     response = lambda_client.get_function_url_config(
                         FunctionName=func.name
                     )
                     break
-                except Exception as e:
+                except lambda_client.exceptions.TooManyRequestsException as e:
+                    # AWS is throttling requests - apply exponential backoff
                     retries += 1
                     if retries == 5:
-                        self.logging.error("Failed to create Function URL!")
-                        self.logging.error(e)
-                        raise RuntimeError("Failed to create Function URL!")
+                        self.logging.error("Failed to create Function URL after 5 retries!")
+                        self.logging.exception(e)
+                        raise RuntimeError("Failed to create Function URL!") from e
                     else:
-                        self.logging.info("Function URL creation failed, retrying...")
-                        time.sleep(retries)
+                        backoff_seconds = retries
+                        self.logging.info(
+                            f"Function URL creation rate limited, "
+                            f"retrying in {backoff_seconds}s (attempt {retries}/5)..."
+                        )
+                        time.sleep(backoff_seconds)
 
             url = response["FunctionUrl"]
 
@@ -626,25 +684,34 @@ class AWSResources(Resources):
             service_name="lambda", region_name=cast(str, self._region)
         )
 
+        # Check if we have cached info about the auth type
+        cached_url = self._function_urls.get(function_name)
+        cached_auth_type = cached_url.auth_type if cached_url else None
+
         try:
             lambda_client.delete_function_url_config(FunctionName=function_name)
             self.logging.info(f"Deleted Function URL for {function_name}")
 
-            try:
-                lambda_client.remove_permission(
-                    FunctionName=function_name,
-                    StatementId="FunctionURLAllowPublicAccess",
-                )
-            except lambda_client.exceptions.ResourceNotFoundException:
-                pass
-
-            if function_name in self._function_urls:
-                del self._function_urls[function_name]
-
-            return True
+            # Only remove the public access permission if auth_type was NONE
+            # (AWS_IAM auth type doesn't create this permission)
+            if cached_auth_type is None or cached_auth_type == FunctionURLAuthType.NONE:
+                try:
+                    lambda_client.remove_permission(
+                        FunctionName=function_name,
+                        StatementId="FunctionURLAllowPublicAccess",
+                    )
+                except lambda_client.exceptions.ResourceNotFoundException:
+                    # Permission doesn't exist - either it was already removed,
+                    # or the function was using AWS_IAM auth type
+                    pass
         except lambda_client.exceptions.ResourceNotFoundException:
             self.logging.info(f"No Function URL found for {function_name}")
             return False
+        else:
+            # Only runs if no exception was raised - cleanup cache
+            if function_name in self._function_urls:
+                del self._function_urls[function_name]
+            return True
 
     def check_ecr_repository_exists(
         self, ecr_client: ECRClient, repository_name: str
@@ -871,7 +938,8 @@ class AWSResources(Resources):
                 ret._function_urls[key] = AWSResources.FunctionURL.deserialize(value)
 
         ret._use_function_url = dct.get("use-function-url", False)
-        ret._function_url_auth_type = dct.get("function-url-auth-type", "NONE")
+        auth_type_str = dct.get("function-url-auth-type", "NONE")
+        ret.function_url_auth_type = FunctionURLAuthType.from_string(auth_type_str)
 
     def serialize(self) -> dict:
         """Serialize AWS resources to dictionary.
@@ -887,7 +955,7 @@ class AWSResources(Resources):
                 key: value.serialize() for (key, value) in self._function_urls.items()
             },
             "use-function-url": self._use_function_url,
-            "function-url-auth-type": self._function_url_auth_type,
+            "function-url-auth-type": self._function_url_auth_type.value,
             "docker": {
                 "registry": self.docker_registry,
                 "username": self.docker_username,
@@ -924,7 +992,8 @@ class AWSResources(Resources):
             val=self._use_function_url, keys=["aws", "resources", "use-function-url"]
         )
         cache.update_config(
-            val=self._function_url_auth_type, keys=["aws", "resources", "function-url-auth-type"]
+            val=self._function_url_auth_type.value,
+            keys=["aws", "resources", "function-url-auth-type"],
         )
 
     @staticmethod

--- a/sebs/aws/config.py
+++ b/sebs/aws/config.py
@@ -603,11 +603,8 @@ class AWSResources(Resources):
         deleted: List[str] = []
         dry_run_tag = "[DRY-RUN] " if dry_run else ""
 
-        function_urls = cache_client.get_config_key(["aws", "resources", "function-urls"])
-        if function_urls is None:
-            return deleted
-
-        for func_name, func_url_data in function_urls.items():
+        dict_copy = self._function_urls.copy()
+        for func_name, _ in dict_copy.items():
 
             self.logging.info(f"{dry_run_tag}Deleting Function URL for: {func_name}")
 

--- a/sebs/aws/config.py
+++ b/sebs/aws/config.py
@@ -288,30 +288,65 @@ class AWSResources(Resources):
             return out
 
     class FunctionURL:
+
+        """Encapsulates single instance of function URL."""
+
         def __init__(
             self,
             url: str,
             function_name: str,
             auth_type: FunctionURLAuthType = FunctionURLAuthType.NONE,
         ):
+            """Initialize AWS function URL instace.
+
+            Args:
+                url:
+                function_name:
+                auth_type:
+            """
             self._url = url
             self._function_name = function_name
             self._auth_type = auth_type
 
         @property
         def url(self) -> str:
+            """URL to invoke function with.
+
+            Returns:
+                URL
+            """
             return self._url
 
         @property
         def function_name(self) -> str:
+            """Function name.
+
+            Returns:
+                name
+            """
             return self._function_name
 
         @property
         def auth_type(self) -> FunctionURLAuthType:
+            """None (public access) or AWS_IAM.
+
+            AWS IAM requires SigV4 signing, currently not supported.
+
+            Returns:
+                Authentication type.
+            """
             return self._auth_type
 
         @staticmethod
         def deserialize(dct: dict) -> "AWSResources.FunctionURL":
+            """Deserialize JSON into instance.
+
+            Args:
+                dct: cached dictionary
+
+            Returns:
+                function URL instance
+            """
             auth_type_str = dct.get("auth_type", "NONE")
             return AWSResources.FunctionURL(
                 dct["url"],
@@ -320,6 +355,11 @@ class AWSResources(Resources):
             )
 
         def serialize(self) -> dict:
+            """Serialize instance into JSON
+
+            Returns:
+                Python dictionary
+            """
             return {
                 "url": self.url,
                 "function_name": self.function_name,
@@ -397,22 +437,36 @@ class AWSResources(Resources):
 
     @property
     def use_function_url(self) -> bool:
+        """
+        Returns:
+            true if HTTP triggers use function URLs
+            [TODO:return]
+        """
         return self._use_function_url
 
     @use_function_url.setter
     def use_function_url(self, value: bool):
+        """
+        Change HTTP Trigger type.
+        True => use function URL.
+        False => use API gateway.
+        """
         self._use_function_url = value
 
     @property
     def function_url_auth_type(self) -> FunctionURLAuthType:
+        """
+        Returns:
+            function URL authentication type (NONE or AWS_IAM)
+        """
         return self._function_url_auth_type
 
     @function_url_auth_type.setter
     def function_url_auth_type(self, value: FunctionURLAuthType):
-        if not isinstance(value, FunctionURLAuthType):
-            raise TypeError(
-                f"function_url_auth_type must be a FunctionURLAuthType enum, got {type(value)}"
-            )
+        """
+        Change function URL authentication type.
+        AWS_IAM requires SigV4 signing, currently not supported.
+        """
         self._function_url_auth_type = value
 
     def lambda_role(self, boto3_session: boto3.session.Session) -> str:

--- a/sebs/aws/config.py
+++ b/sebs/aws/config.py
@@ -539,7 +539,10 @@ class AWSResources(Resources):
         return http_api
 
     def cleanup_http_apis(
-        self, boto3_session: boto3.session.Session, cache_client: Cache, dry_run: bool = False
+        self,
+        boto3_session: boto3.session.Session,
+        cache_client: Cache,
+        dry_run: bool = False,
     ) -> List[str]:
         """Remove HTTP APIs allocated for HTTP triggers.
 
@@ -580,6 +583,45 @@ class AWSResources(Resources):
 
         return deleted
 
+    def cleanup_function_urls(
+        self,
+        boto3_session: boto3.session.Session,
+        cache_client: Cache,
+        dry_run: bool = False,
+    ) -> List[str]:
+        """Remove Function URLs allocated for HTTP triggers.
+
+        Args:
+            boto3_session: boto3 session for AWS API calls
+            cache_client: SeBS cache client
+            dry_run: when true, skip actual deletion
+
+        Returns:
+            list of deleted Function URL names (function names)
+        """
+
+        deleted: List[str] = []
+        dry_run_tag = "[DRY-RUN] " if dry_run else ""
+
+        function_urls = cache_client.get_config_key(["aws", "resources", "function-urls"])
+        if function_urls is None:
+            return deleted
+
+        for func_name, func_url_data in function_urls.items():
+
+            self.logging.info(f"{dry_run_tag}Deleting Function URL for: {func_name}")
+
+            if not dry_run:
+                self.delete_function_url(func_name, boto3_session)
+            deleted.append(func_name)
+
+        if not dry_run:
+            for func_name in deleted:
+                cache_client.remove_config_key(["aws", "resources", "function-urls", func_name])
+                self._function_urls.pop(func_name, None)
+
+        return deleted
+
     def function_url(
         self, func: LambdaFunction, boto3_session: boto3.session.Session
     ) -> "AWSResources.FunctionURL":
@@ -587,6 +629,9 @@ class AWSResources(Resources):
         Create or retrieve a Lambda Function URL for the given function.
         Function URLs provide a simpler alternative to API Gateway without the
         29-second timeout limit.
+
+        Permissions are applied whenever the Function URL is not cached locally,
+        ensuring correct access policies for both newly created and existing URLs.
         """
         cached_url = self._function_urls.get(func.name)
         if cached_url:
@@ -605,41 +650,23 @@ class AWSResources(Resources):
             service_name="lambda", region_name=cast(str, self._region)
         )
 
+        # Try to get existing Function URL configuration from AWS
+        url_exists = False
         try:
             response = lambda_client.get_function_url_config(FunctionName=func.name)
-            self.logging.info(f"Using existing Function URL for {func.name}")
+            self.logging.info(f"Found existing Function URL for {func.name}")
             url = response["FunctionUrl"]
             auth_type = FunctionURLAuthType.from_string(response["AuthType"])
+            url_exists = True
         except lambda_client.exceptions.ResourceNotFoundException:
+            # Function URL doesn't exist - we'll create it
             self.logging.info(f"Creating Function URL for {func.name}")
-
             auth_type = self._function_url_auth_type
-
-            if auth_type == FunctionURLAuthType.NONE:
-                self.logging.warning(
-                    f"Creating Function URL with auth_type=NONE for {func.name}. "
-                    "WARNING: This function will have unrestricted public access. "
-                    "Anyone with the URL can invoke this function."
-                )
-                try:
-                    lambda_client.add_permission(
-                        FunctionName=func.name,
-                        StatementId="FunctionURLAllowPublicAccess",
-                        Action="lambda:InvokeFunctionUrl",
-                        Principal="*",
-                        FunctionUrlAuthType="NONE",
-                    )
-                except lambda_client.exceptions.ResourceConflictException:
-                    # Permission with this StatementId already exists on the function.
-                    # This can happen if the function was previously configured with
-                    # a Function URL that was deleted but the permission remained,
-                    # or if there's a concurrent creation attempt. Safe to ignore.
-                    pass
 
             retries = 0
             while retries < 5:
                 try:
-                    response = lambda_client.create_function_url_config(
+                    response = lambda_client.create_function_url_config(  # type: ignore[assignment]
                         FunctionName=func.name,
                         AuthType=auth_type.value,
                     )
@@ -648,16 +675,14 @@ class AWSResources(Resources):
                     # Function URL already exists - can happen if a concurrent process
                     # created it between our check and create, or if there was a race
                     # condition. Retrieve the existing configuration instead.
-                    response = lambda_client.get_function_url_config(
-                        FunctionName=func.name
-                    )
+                    response = lambda_client.get_function_url_config(FunctionName=func.name)
                     break
                 except lambda_client.exceptions.TooManyRequestsException as e:
                     # AWS is throttling requests - apply exponential backoff
                     retries += 1
                     if retries == 5:
                         self.logging.error("Failed to create Function URL after 5 retries!")
-                        self.logging.exception(e)
+                        self.logging.error(e)
                         raise RuntimeError("Failed to create Function URL!") from e
                     else:
                         backoff_seconds = retries
@@ -669,13 +694,36 @@ class AWSResources(Resources):
 
             url = response["FunctionUrl"]
 
+        # Apply permissions for NONE auth type (applies to both new and existing URLs)
+        # This ensures correct permissions even if the Function URL was created externally
+        if auth_type == FunctionURLAuthType.NONE:
+            action_verb = "found" if url_exists else "created"
+            self.logging.warning(
+                f"Function URL {action_verb} with auth_type=NONE for {func.name}. "
+                "WARNING: This function will have unrestricted public access. "
+                "Anyone with the URL can invoke this function."
+            )
+            try:
+                lambda_client.add_permission(
+                    FunctionName=func.name,
+                    StatementId="FunctionURLAllowPublicAccess",
+                    Action="lambda:InvokeFunctionUrl",
+                    Principal="*",
+                    FunctionUrlAuthType="NONE",
+                )
+                self.logging.info(
+                    f"Applied public access permission for Function URL on {func.name}"
+                )
+            except lambda_client.exceptions.ResourceConflictException:
+                # Permission with this StatementId already exists on the function.
+                # This is expected if the permission was previously added.
+                self.logging.info(f"Public access permission already exists for {func.name}")
+
         function_url_obj = AWSResources.FunctionURL(url, func.name, auth_type)
         self._function_urls[func.name] = function_url_obj
         return function_url_obj
 
-    def delete_function_url(
-        self, function_name: str, boto3_session: boto3.session.Session
-    ) -> bool:
+    def delete_function_url(self, function_name: str, boto3_session: boto3.session.Session) -> bool:
         """
         Delete a Lambda Function URL for the given function.
         Returns True if deleted successfully, False if it didn't exist.
@@ -834,7 +882,10 @@ class AWSResources(Resources):
         return deleted
 
     def cleanup_cloudwatch_logs(
-        self, function_names: List[str], boto3_session: boto3.session.Session, dry_run: bool
+        self,
+        function_names: List[str],
+        boto3_session: boto3.session.Session,
+        dry_run: bool,
     ) -> List[str]:
         """Remove CloudWatch logs for selected functions.
 
@@ -986,7 +1037,8 @@ class AWSResources(Resources):
             cache.update_config(val=api.serialize(), keys=["aws", "resources", "http-apis", name])
         for name, func_url in self._function_urls.items():
             cache.update_config(
-                val=func_url.serialize(), keys=["aws", "resources", "function-urls", name]
+                val=func_url.serialize(),
+                keys=["aws", "resources", "function-urls", name],
             )
         cache.update_config(
             val=self._use_function_url, keys=["aws", "resources", "use-function-url"]

--- a/sebs/aws/config.py
+++ b/sebs/aws/config.py
@@ -601,6 +601,7 @@ class AWSResources(Resources):
         """
 
         deleted: List[str] = []
+        deleted_functions: List[str] = []
         dry_run_tag = "[DRY-RUN] " if dry_run else ""
 
         dict_copy = self._function_urls.copy()
@@ -611,9 +612,10 @@ class AWSResources(Resources):
             if not dry_run:
                 self.delete_function_url(func_name, boto3_session)
             deleted.append(func_url.url)
+            deleted_functions.append(func_name)
 
         if not dry_run:
-            for func_name in deleted:
+            for func_name in deleted_functions:
                 cache_client.remove_config_key(["aws", "resources", "function-urls", func_name])
                 self._function_urls.pop(func_name, None)
 

--- a/sebs/aws/function.py
+++ b/sebs/aws/function.py
@@ -115,10 +115,7 @@ class LambdaFunction(Function):
         for trigger in cached_config["triggers"]:
             trigger_type = cast(
                 Trigger,
-                {
-                    "Library": LibraryTrigger,
-                    "HTTP": HTTPTrigger
-                }.get(trigger["type"]),
+                {"Library": LibraryTrigger, "HTTP": HTTPTrigger}.get(trigger["type"]),
             )
             assert trigger_type, "Unknown trigger type {}".format(trigger["type"])
             ret.add_trigger(trigger_type.deserialize(trigger))

--- a/sebs/aws/function.py
+++ b/sebs/aws/function.py
@@ -99,7 +99,7 @@ class LambdaFunction(Function):
             AssertionError: If an unknown trigger type is encountered
         """
         from sebs.faas.function import Trigger
-        from sebs.aws.triggers import LibraryTrigger, HTTPTrigger
+        from sebs.aws.triggers import LibraryTrigger, HTTPTrigger, FunctionURLTrigger
 
         cfg = FunctionConfig.deserialize(cached_config["config"])
         ret = LambdaFunction(
@@ -115,7 +115,11 @@ class LambdaFunction(Function):
         for trigger in cached_config["triggers"]:
             trigger_type = cast(
                 Trigger,
-                {"Library": LibraryTrigger, "HTTP": HTTPTrigger}.get(trigger["type"]),
+                {
+                    "Library": LibraryTrigger,
+                    "HTTP": HTTPTrigger,
+                    "FunctionURL": FunctionURLTrigger,
+                }.get(trigger["type"]),
             )
             assert trigger_type, "Unknown trigger type {}".format(trigger["type"])
             ret.add_trigger(trigger_type.deserialize(trigger))

--- a/sebs/aws/function.py
+++ b/sebs/aws/function.py
@@ -99,7 +99,7 @@ class LambdaFunction(Function):
             AssertionError: If an unknown trigger type is encountered
         """
         from sebs.faas.function import Trigger
-        from sebs.aws.triggers import LibraryTrigger, HTTPTrigger, FunctionURLTrigger
+        from sebs.aws.triggers import LibraryTrigger, HTTPTrigger
 
         cfg = FunctionConfig.deserialize(cached_config["config"])
         ret = LambdaFunction(
@@ -117,8 +117,7 @@ class LambdaFunction(Function):
                 Trigger,
                 {
                     "Library": LibraryTrigger,
-                    "HTTP": HTTPTrigger,
-                    "FunctionURL": FunctionURLTrigger,
+                    "HTTP": HTTPTrigger
                 }.get(trigger["type"]),
             )
             assert trigger_type, "Unknown trigger type {}".format(trigger["type"])

--- a/sebs/aws/triggers.py
+++ b/sebs/aws/triggers.py
@@ -278,3 +278,49 @@ class HTTPTrigger(Trigger):
             Trigger: Deserialized HTTPTrigger instance
         """
         return HTTPTrigger(obj["url"], obj["api-id"])
+
+
+class FunctionURLTrigger(Trigger):
+    """
+    Trigger using AWS Lambda Function URLs instead of API Gateway.
+    Function URLs provide a simpler alternative without the 29-second timeout limit.
+    """
+
+    def __init__(self, url: str, function_name: str, auth_type: str = "NONE"):
+        super().__init__()
+        self.url = url
+        self.function_name = function_name
+        self.auth_type = auth_type
+
+    @staticmethod
+    def typename() -> str:
+        return "AWS.FunctionURLTrigger"
+
+    @staticmethod
+    def trigger_type() -> Trigger.TriggerType:
+        return Trigger.TriggerType.HTTP
+
+    def sync_invoke(self, payload: dict) -> ExecutionResult:
+        self.logging.debug(f"Invoke function via Function URL {self.url}")
+        return self._http_invoke(payload, self.url)
+
+    def async_invoke(self, payload: dict) -> concurrent.futures.Future:
+        pool = concurrent.futures.ThreadPoolExecutor()
+        fut = pool.submit(self.sync_invoke, payload)
+        return fut
+
+    def serialize(self) -> dict:
+        return {
+            "type": "FunctionURL",
+            "url": self.url,
+            "function_name": self.function_name,
+            "auth_type": self.auth_type,
+        }
+
+    @staticmethod
+    def deserialize(obj: dict) -> Trigger:
+        return FunctionURLTrigger(
+            obj["url"],
+            obj["function_name"],
+            obj.get("auth_type", "NONE"),
+        )

--- a/sebs/aws/triggers.py
+++ b/sebs/aws/triggers.py
@@ -323,7 +323,6 @@ class HTTPTrigger(Trigger):
         """
         pool = concurrent.futures.ThreadPoolExecutor()
         fut = pool.submit(self.sync_invoke, payload)
-        pool.shutdown(wait=False)
         return fut
 
     def serialize(self) -> dict:

--- a/sebs/aws/triggers.py
+++ b/sebs/aws/triggers.py
@@ -14,11 +14,19 @@ import base64
 import concurrent.futures
 import datetime
 import json
+from enum import Enum
 from typing import Dict, Optional  # noqa
 
 from sebs.aws.aws import AWS
 from sebs.aws.config import FunctionURLAuthType
 from sebs.faas.function import ExecutionResult, Trigger
+
+
+class HTTPTriggerImplementation(Enum):
+    """Internal implementation type for HTTP triggers."""
+
+    API_GATEWAY = "api_gateway"
+    FUNCTION_URL = "function_url"
 
 
 class LibraryTrigger(Trigger):
@@ -190,27 +198,70 @@ class LibraryTrigger(Trigger):
 
 
 class HTTPTrigger(Trigger):
-    """AWS API Gateway HTTP trigger for Lambda functions.
+    """AWS HTTP trigger for Lambda functions.
 
-    This trigger uses HTTP requests to invoke Lambda functions through
-    AWS API Gateway. It provides both synchronous and asynchronous
-    invocation methods.
+    This trigger uses HTTP requests to invoke Lambda functions through either
+    AWS API Gateway or Lambda Function URLs. The implementation is transparent
+    to the user - both are accessed as HTTP triggers.
 
     Attributes:
-        url: API Gateway endpoint URL
-        api_id: API Gateway API ID
+        url: HTTP endpoint URL (API Gateway or Function URL)
+        implementation: Internal implementation type (API Gateway or Function URL)
+        api_id: API Gateway API ID (only for API Gateway implementation)
+        function_name: Function name (only for Function URL implementation)
+        auth_type: Authentication type (only for Function URL implementation)
     """
 
-    def __init__(self, url: str, api_id: str) -> None:
+    def __init__(
+        self,
+        url: str,
+        implementation: HTTPTriggerImplementation = HTTPTriggerImplementation.API_GATEWAY,
+        api_id: Optional[str] = None,
+        function_name: Optional[str] = None,
+        auth_type: Optional[FunctionURLAuthType] = None,
+    ) -> None:
         """Initialize the HTTP trigger.
 
         Args:
-            url: API Gateway endpoint URL
-            api_id: API Gateway API ID
+            url: HTTP endpoint URL
+            implementation: Implementation type (API Gateway or Function URL)
+            api_id: API Gateway API ID (required for API Gateway)
+            function_name: Function name (required for Function URL)
+            auth_type: Authentication type (for Function URL, defaults to NONE)
         """
         super().__init__()
         self.url = url
+        self._implementation = implementation
         self.api_id = api_id
+        self.function_name = function_name
+        self.auth_type = auth_type if auth_type is not None else FunctionURLAuthType.NONE
+
+    @property
+    def implementation(self) -> HTTPTriggerImplementation:
+        """Get the implementation type of this HTTP trigger.
+
+        Returns:
+            HTTPTriggerImplementation: API_GATEWAY or FUNCTION_URL
+        """
+        return self._implementation
+
+    @property
+    def uses_api_gateway(self) -> bool:
+        """Check if this trigger uses API Gateway.
+
+        Returns:
+            bool: True if using API Gateway, False otherwise
+        """
+        return self._implementation == HTTPTriggerImplementation.API_GATEWAY
+
+    @property
+    def uses_function_url(self) -> bool:
+        """Check if this trigger uses Lambda Function URLs.
+
+        Returns:
+            bool: True if using Function URLs, False otherwise
+        """
+        return self._implementation == HTTPTriggerImplementation.FUNCTION_URL
 
     @staticmethod
     def typename() -> str:
@@ -233,15 +284,29 @@ class HTTPTrigger(Trigger):
     def sync_invoke(self, payload: dict) -> ExecutionResult:
         """Synchronously invoke the function via HTTP.
 
-        Sends an HTTP request to the API Gateway endpoint and waits
-        for the response.
+        Sends an HTTP request to the endpoint (API Gateway or Function URL)
+        and waits for the response.
 
         Args:
             payload: Dictionary payload to send to the function
 
         Returns:
             ExecutionResult: Result of the HTTP invocation
+
+        Raises:
+            NotImplementedError: If using AWS_IAM auth with Function URLs
         """
+        # Check for unsupported AWS_IAM auth with Function URLs
+        if (
+            self._implementation == HTTPTriggerImplementation.FUNCTION_URL
+            and self.auth_type == FunctionURLAuthType.AWS_IAM
+        ):
+            raise NotImplementedError(
+                "AWS_IAM auth type requires SigV4 signing, which is not yet "
+                "implemented for Function URLs. Use auth_type=NONE or "
+                "implement SigV4 signing via botocore.auth.SigV4Auth."
+            )
+
         self.logging.debug(f"Invoke function {self.url}")
         return self._http_invoke(payload, self.url)
 
@@ -258,15 +323,30 @@ class HTTPTrigger(Trigger):
         """
         pool = concurrent.futures.ThreadPoolExecutor()
         fut = pool.submit(self.sync_invoke, payload)
+        pool.shutdown(wait=False)
         return fut
 
     def serialize(self) -> dict:
         """Serialize the trigger to a dictionary.
 
         Returns:
-            dict: Serialized trigger configuration
+            dict: Serialized trigger configuration including implementation details
         """
-        return {"type": "HTTP", "url": self.url, "api-id": self.api_id}
+        base = {
+            "type": "HTTP",
+            "url": self.url,
+            "implementation": self._implementation.value,
+        }
+
+        if self._implementation == HTTPTriggerImplementation.API_GATEWAY:
+            if self.api_id is not None:
+                base["api-id"] = self.api_id
+        else:  # FUNCTION_URL
+            if self.function_name is not None:
+                base["function_name"] = self.function_name
+            base["auth_type"] = self.auth_type.value
+
+        return base
 
     @staticmethod
     def deserialize(obj: dict) -> Trigger:
@@ -278,63 +358,29 @@ class HTTPTrigger(Trigger):
         Returns:
             Trigger: Deserialized HTTPTrigger instance
         """
-        return HTTPTrigger(obj["url"], obj["api-id"])
+        # Check for implementation field (new format)
+        if "implementation" in obj:
+            impl_value = obj["implementation"]
+            implementation = HTTPTriggerImplementation(impl_value)
 
-
-class FunctionURLTrigger(Trigger):
-    """
-    Trigger using AWS Lambda Function URLs instead of API Gateway.
-    Function URLs provide a simpler alternative without the 29-second timeout limit.
-    """
-
-    def __init__(
-        self,
-        url: str,
-        function_name: str,
-        auth_type: FunctionURLAuthType = FunctionURLAuthType.NONE,
-    ):
-        super().__init__()
-        self.url = url
-        self.function_name = function_name
-        self.auth_type = auth_type
-
-    @staticmethod
-    def typename() -> str:
-        return "AWS.FunctionURLTrigger"
-
-    @staticmethod
-    def trigger_type() -> Trigger.TriggerType:
-        return Trigger.TriggerType.HTTP
-
-    def sync_invoke(self, payload: dict) -> ExecutionResult:
-        self.logging.debug(f"Invoke function via Function URL {self.url}")
-        if self.auth_type == FunctionURLAuthType.AWS_IAM:
-            raise NotImplementedError(
-                "AWS_IAM auth type requires SigV4 signing, which is not yet "
-                "implemented in FunctionURLTrigger. Use auth_type=NONE or "
-                "implement SigV4 signing via botocore.auth.SigV4Auth."
+            if implementation == HTTPTriggerImplementation.API_GATEWAY:
+                return HTTPTrigger(
+                    url=obj["url"],
+                    implementation=implementation,
+                    api_id=obj.get("api-id"),
+                )
+            else:  # FUNCTION_URL
+                auth_type_str = obj.get("auth_type", "NONE")
+                return HTTPTrigger(
+                    url=obj["url"],
+                    implementation=implementation,
+                    function_name=obj.get("function_name"),
+                    auth_type=FunctionURLAuthType.from_string(auth_type_str),
+                )
+        else:
+            # Legacy format compatibility - assume API Gateway
+            return HTTPTrigger(
+                url=obj["url"],
+                implementation=HTTPTriggerImplementation.API_GATEWAY,
+                api_id=obj.get("api-id"),
             )
-        return self._http_invoke(payload, self.url)
-
-    def async_invoke(self, payload: dict) -> concurrent.futures.Future:
-        pool = concurrent.futures.ThreadPoolExecutor()
-        fut = pool.submit(self.sync_invoke, payload)
-        pool.shutdown(wait=False)
-        return fut
-
-    def serialize(self) -> dict:
-        return {
-            "type": "FunctionURL",
-            "url": self.url,
-            "function_name": self.function_name,
-            "auth_type": self.auth_type.value,
-        }
-
-    @staticmethod
-    def deserialize(obj: dict) -> Trigger:
-        auth_type_str = obj.get("auth_type", "NONE")
-        return FunctionURLTrigger(
-            obj["url"],
-            obj["function_name"],
-            FunctionURLAuthType.from_string(auth_type_str),
-        )

--- a/sebs/aws/triggers.py
+++ b/sebs/aws/triggers.py
@@ -17,6 +17,7 @@ import json
 from typing import Dict, Optional  # noqa
 
 from sebs.aws.aws import AWS
+from sebs.aws.config import FunctionURLAuthType
 from sebs.faas.function import ExecutionResult, Trigger
 
 
@@ -286,7 +287,12 @@ class FunctionURLTrigger(Trigger):
     Function URLs provide a simpler alternative without the 29-second timeout limit.
     """
 
-    def __init__(self, url: str, function_name: str, auth_type: str = "NONE"):
+    def __init__(
+        self,
+        url: str,
+        function_name: str,
+        auth_type: FunctionURLAuthType = FunctionURLAuthType.NONE,
+    ):
         super().__init__()
         self.url = url
         self.function_name = function_name
@@ -302,11 +308,18 @@ class FunctionURLTrigger(Trigger):
 
     def sync_invoke(self, payload: dict) -> ExecutionResult:
         self.logging.debug(f"Invoke function via Function URL {self.url}")
+        if self.auth_type == FunctionURLAuthType.AWS_IAM:
+            raise NotImplementedError(
+                "AWS_IAM auth type requires SigV4 signing, which is not yet "
+                "implemented in FunctionURLTrigger. Use auth_type=NONE or "
+                "implement SigV4 signing via botocore.auth.SigV4Auth."
+            )
         return self._http_invoke(payload, self.url)
 
     def async_invoke(self, payload: dict) -> concurrent.futures.Future:
         pool = concurrent.futures.ThreadPoolExecutor()
         fut = pool.submit(self.sync_invoke, payload)
+        pool.shutdown(wait=False)
         return fut
 
     def serialize(self) -> dict:
@@ -314,13 +327,14 @@ class FunctionURLTrigger(Trigger):
             "type": "FunctionURL",
             "url": self.url,
             "function_name": self.function_name,
-            "auth_type": self.auth_type,
+            "auth_type": self.auth_type.value,
         }
 
     @staticmethod
     def deserialize(obj: dict) -> Trigger:
+        auth_type_str = obj.get("auth_type", "NONE")
         return FunctionURLTrigger(
             obj["url"],
             obj["function_name"],
-            obj.get("auth_type", "NONE"),
+            FunctionURLAuthType.from_string(auth_type_str),
         )

--- a/tests/aws/test_function_url.py
+++ b/tests/aws/test_function_url.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import tempfile
 import unittest
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import sebs
 from sebs.faas.function import Trigger
@@ -98,9 +98,11 @@ class AWSFunctionURL(unittest.TestCase):
         self.assertGreater(len(all_triggers), 0)
 
         function_url_trigger = all_triggers[0]
-        from sebs.aws.triggers import FunctionURLTrigger
+        from sebs.aws.triggers import HTTPTrigger
 
-        self.assertIsInstance(function_url_trigger, FunctionURLTrigger)
+        self.assertIsInstance(function_url_trigger, HTTPTrigger)
+        self.assertTrue(function_url_trigger.uses_function_url)
+        self.assertFalse(function_url_trigger.uses_api_gateway)
         self.assertTrue(function_url_trigger.url)
         self.assertTrue(function_url_trigger.url.startswith("https://"))
 
@@ -135,6 +137,76 @@ class AWSFunctionURL(unittest.TestCase):
         self.assertIn("Function URLs", cleanup_result)
         self.assertEqual(len(cleanup_result["Function URLs"]), 1)
         self.assertEqual(cleanup_result["Function URLs"][0], func_url)
+
+    def test_api_gateway_still_works(self):
+        """Test that API Gateway triggers still work alongside Function URLs.
+
+        Verifies:
+        1. A single function can have both API Gateway and Function URL triggers
+        2. Both trigger types are distinct HTTPTrigger instances
+        3. Both triggers work with invocation
+        """
+        from sebs.aws.triggers import HTTPTrigger
+
+        # Save original config
+        original_use_function_url = self.deployment_client.config.resources.use_function_url
+
+        try:
+            func = self._get_function("dual-func-url")
+
+            http_triggers = func.triggers(Trigger.TriggerType.HTTP)
+
+            # Create API Gateway trigger first
+            self.deployment_client.config.resources.use_function_url = False
+            self.deployment_client.create_trigger(func, Trigger.TriggerType.HTTP)
+
+            # Add Function URL trigger to the same function
+            self.deployment_client.config.resources.use_function_url = True
+            self.deployment_client.create_trigger(func, Trigger.TriggerType.HTTP)
+
+            # Verify we have 2 HTTP triggers
+            http_triggers = func.triggers(Trigger.TriggerType.HTTP)
+            self.assertEqual(len(http_triggers), 2)
+
+            # Find each trigger type
+            api_gw_trigger = None
+            func_url_trigger = None
+
+            for trigger in http_triggers:
+                self.assertIsInstance(trigger, HTTPTrigger)
+                trigger_aws = cast(sebs.aws.triggers.HTTPTrigger, trigger)
+                if trigger_aws.uses_api_gateway:
+                    api_gw_trigger = trigger
+                elif trigger_aws.uses_function_url:
+                    func_url_trigger = trigger
+
+            # Verify both types exist
+            self.assertIsNotNone(api_gw_trigger, "API Gateway trigger not found")
+            self.assertIsNotNone(func_url_trigger, "Function URL trigger not found")
+
+            # Verify API Gateway trigger properties
+            self.assertTrue(api_gw_trigger.uses_api_gateway)
+            self.assertFalse(api_gw_trigger.uses_function_url)
+            self.assertTrue(api_gw_trigger.url.startswith("https://"))
+
+            # Verify Function URL trigger properties
+            self.assertTrue(func_url_trigger.uses_function_url)
+            self.assertFalse(func_url_trigger.uses_api_gateway)
+            self.assertTrue(func_url_trigger.url.startswith("https://"))
+
+            # Verify different URLs
+            self.assertNotEqual(api_gw_trigger.url, func_url_trigger.url)
+
+            # Test invocation via both triggers
+            ret_api_gw = api_gw_trigger.sync_invoke(self.bench_input)
+            self.assertFalse(ret_api_gw.stats.failure)
+
+            ret_func_url = func_url_trigger.sync_invoke(self.bench_input)
+            self.assertFalse(ret_func_url.stats.failure)
+
+        finally:
+            # Restore original config
+            self.deployment_client.config.resources.use_function_url = original_use_function_url
 
 
 if __name__ == "__main__":

--- a/tests/aws/test_function_url.py
+++ b/tests/aws/test_function_url.py
@@ -135,8 +135,9 @@ class AWSFunctionURL(unittest.TestCase):
         # Dry run first to verify detection
         cleanup_result = self.deployment_client.cleanup_resources(dry_run=True)
         self.assertIn("Function URLs", cleanup_result)
-        self.assertEqual(len(cleanup_result["Function URLs"]), 1)
-        self.assertEqual(cleanup_result["Function URLs"][0], func_url)
+        self.assertGreaterEqual(len(cleanup_result["Function URLs"]), 1)
+
+        self.assertIn(func_url, cleanup_result["Function URLs"])
 
     def test_api_gateway_still_works(self):
         """Test that API Gateway triggers still work alongside Function URLs.

--- a/tests/aws/test_function_url.py
+++ b/tests/aws/test_function_url.py
@@ -1,0 +1,141 @@
+# Copyright 2020-2025 ETH Zurich and the SeBS authors. All rights reserved.
+from __future__ import annotations
+
+import tempfile
+import unittest
+from typing import TYPE_CHECKING
+
+import sebs
+from sebs.faas.function import Trigger
+
+if TYPE_CHECKING:
+    import sebs.aws
+
+
+class AWSFunctionURL(unittest.TestCase):
+    """Integration tests for AWS Lambda Function URLs.
+
+    Tests Function URL creation, invocation, caching, and cleanup.
+    A single deployment client and benchmark are shared across all tests
+    to avoid redundant Docker builds and resource initialization.
+    """
+
+    BENCHMARK_NAME = "110.dynamic-html"
+    RESOURCE_PREFIX = "unit"
+
+    BASE_CONFIG = {
+        "deployment": {
+            "name": "aws",
+            "aws": {
+                "region": "us-east-1",
+                "resources": {
+                    "use-function-url": True,
+                    "function-url-auth-type": "NONE",
+                },
+            },
+        },
+        "experiments": {
+            "deployment": "aws",
+            "runtime": {"language": "python", "version": "3.9"},
+            "update_code": False,
+            "update_storage": False,
+            "download_results": False,
+            "architecture": "x64",
+            "container_deployment": False,
+        },
+    }
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp_dir = tempfile.TemporaryDirectory()
+        cls.client = sebs.SeBS(cls.tmp_dir.name, cls.tmp_dir.name)
+
+        # Shared Python deployment client and benchmark
+        cls.deployment_client = cls.client.get_deployment(cls.BASE_CONFIG)
+        cls.deployment_client.initialize(resource_prefix=cls.RESOURCE_PREFIX)
+        cls.experiment_config = cls.client.get_experiment_config(cls.BASE_CONFIG["experiments"])
+        cls.benchmark = cls.client.get_benchmark(
+            cls.BENCHMARK_NAME, cls.deployment_client, cls.experiment_config
+        )
+        cls.bench_input = cls.benchmark.prepare_input(
+            system_resources=cls.deployment_client.system_resources, size="test"
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+
+        cls.deployment_client.cleanup_resources(dry_run=False)
+
+        # Shut down deployment client (stops containers) before removing temp dir
+        if hasattr(cls, "deployment_client"):
+            cls.deployment_client.shutdown()
+        cls.tmp_dir.cleanup()
+
+    def _get_function(self, suffix: str) -> sebs.aws.LambdaFunction:
+        """Create/get a function with the given suffix appended to the default name."""
+        name = "{}-{}".format(self.deployment_client.default_function_name(self.benchmark), suffix)
+        return self.deployment_client.get_function(self.benchmark, name)
+
+    def _invoke_sync(self, func: sebs.aws.LambdaFunction, func_input: dict):
+        """Helper method to invoke function via Function URL and verify response."""
+        triggers = func.triggers(Trigger.TriggerType.HTTP)
+        self.assertGreater(len(triggers), 0, "No HTTP triggers found on function")
+        ret = triggers[0].sync_invoke(func_input)
+        self.assertFalse(ret.stats.failure)
+        self.assertTrue(ret.request_id)
+        self.assertGreater(ret.times.client, ret.times.benchmark)
+
+    # ------------------------------------------------------------------
+    # Tests
+    # ------------------------------------------------------------------
+
+    def test_create_function_url_python(self):
+        """Test Function URL creation with Python runtime and auth_type=NONE."""
+        func = self._get_function("func-url")
+        self.deployment_client.create_trigger(func, Trigger.TriggerType.HTTP)
+
+        all_triggers = func.triggers(Trigger.TriggerType.HTTP)
+        self.assertGreater(len(all_triggers), 0)
+
+        function_url_trigger = all_triggers[0]
+        from sebs.aws.triggers import FunctionURLTrigger
+
+        self.assertIsInstance(function_url_trigger, FunctionURLTrigger)
+        self.assertTrue(function_url_trigger.url)
+        self.assertTrue(function_url_trigger.url.startswith("https://"))
+
+    def test_invoke_function_url_python(self):
+        """Test function invocation via Function URL with Python runtime."""
+        func = self._get_function("func-url")
+        self.deployment_client.create_trigger(func, Trigger.TriggerType.HTTP)
+        self._invoke_sync(func, self.bench_input)
+
+    def test_function_url_caching(self):
+        """Test that Function URLs are cached and reused properly."""
+        func = self._get_function("func-url")
+        self.deployment_client.create_trigger(func, Trigger.TriggerType.HTTP)
+        first_url = func.triggers(Trigger.TriggerType.HTTP)[0].url
+
+        # Get function again — should use cached Function URL
+        func2 = self._get_function("func-url")
+        self.deployment_client.create_trigger(func2, Trigger.TriggerType.HTTP)
+        second_url = func2.triggers(Trigger.TriggerType.HTTP)[0].url
+
+        self.assertEqual(first_url, second_url)
+
+    def test_function_url_cleanup(self):
+        """Test that Function URLs are deleted during cleanup."""
+        func = self._get_function("func-url")
+        self.deployment_client.create_trigger(func, Trigger.TriggerType.HTTP)
+        func_url = func.triggers(Trigger.TriggerType.HTTP)[0].url
+        self.assertTrue(func_url)
+
+        # Dry run first to verify detection
+        cleanup_result = self.deployment_client.cleanup_resources(dry_run=True)
+        self.assertIn("Function URLs", cleanup_result)
+        self.assertEqual(len(cleanup_result["Function URLs"]), 1)
+        self.assertEqual(cleanup_result["Function URLs"][0], func_url)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds support for AWS Lambda Function URLs as an alternative to API Gateway for HTTP triggers
- Function URLs provide a simpler alternative without the 29-second timeout limit of API Gateway
- Keeps API Gateway as the default for backward compatibility

## Changes

- **New `FunctionURLTrigger` class** in `sebs/aws/triggers.py` - HTTP trigger implementation using Lambda Function URLs
- **New configuration options** in `sebs/aws/config.py`:
  - `use-function-url` (bool, default: `false`) - Enable Function URLs instead of API Gateway
  - `function-url-auth-type` (`"NONE"` | `"AWS_IAM"`, default: `"NONE"`) - Authentication type
- **Function URL caching** - Created URLs are cached similar to HTTP APIs
- **Cleanup support** - Added `delete_function_url()` method for resource cleanup
- **Updated trigger creation** in `sebs/aws/aws.py` to check config flag and create appropriate trigger type

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Lambda Function URL support as an alternative to API Gateway HTTP triggers.
  * New config options to enable Function URLs and choose auth type (NONE or AWS_IAM).
  * Automatic creation, caching, persistence, and deletion of Function URLs with appropriate permissions and cleanup integration.
* **Tests**
  * Added integration tests for creating, invoking, caching, and cleaning up Function URL triggers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->