### PR TITLE
[benchmarks] Update input of 120.uploader

### DIFF
--- a/benchmarks/100.webapps/120.uploader/README.md
+++ b/benchmarks/100.webapps/120.uploader/README.md
@@ -9,3 +9,8 @@
 The benchmark implements the common workflow of uploading user-defined data to the persistent cloud storage. It accepts a URL, downloads file contents, and uploads them to the storage. Python implementation uses the standard library `requests`, while the Node.js version uses the third-party `requests` library installed with `npm`.
 
 While 128 MB is technically sufficient for memory size, a larger memory value or a longer timeout might be required for the `large` input size.
+
+It works with the three types of inputs:
+* `test` fetches a small image from Wikipedia.
+* `small` downloads a release of HPX source code from GitHub.
+* `large` downloads a larger ResNet model file from PyTorch website.

--- a/benchmarks/100.webapps/120.uploader/input.py
+++ b/benchmarks/100.webapps/120.uploader/input.py
@@ -4,8 +4,10 @@ import os
 import tempfile
 
 url_generators = {
-    # source: mlperf fake_imagenet.sh. 230 kB
-    'test' : 'https://upload.wikimedia.org/wikipedia/commons/thumb/e/e7/Jammlich_crop.jpg/800px-Jammlich_crop.jpg',
+    # source: mlperf fake_imagenet.sh. 261.6 kB thumbnail at 960px (previously 230 kB) at 800px
+    # Wikimedia now only serves direct thumbnail URLs at standard widths.
+    # 960px is the standard thumbnail corresponding to the former 800px input.
+    'test': 'https://upload.wikimedia.org/wikipedia/commons/thumb/e/e7/Jammlich_crop.jpg/960px-Jammlich_crop.jpg',
     # video: HPX source code, 6.7 MB
     'small': 'https://github.com/STEllAR-GROUP/hpx/archive/refs/tags/1.4.0.zip',
     # resnet model from pytorch. 98M
@@ -16,7 +18,7 @@ url_generators = {
 # These are computed from the objects at the URLs above and must be updated
 # if the remote files change.
 expected_checksums = {
-    'test': '91799b8ca818598fc5b8790f3b338150',
+    'test': '4a1c793ab4b876213eaebdee937c9320',
     'small': 'baf7ea99128aa3e5c2d0c8b8f61cce1b',
     'large': '9e9c86b324d80e65229fab49b8d9a8e8'
 }

--- a/sebs/gcp/gcp.py
+++ b/sebs/gcp/gcp.py
@@ -1436,7 +1436,8 @@ class RunContainerStrategy(DeploymentStrategy):
 
         op_name = self._operation_response["name"]
         self.logging.info(f"Waiting for operation: {op_name}")
-        op_res = self.run_client.projects().locations().operations().wait(name=op_name).execute()
+        # mypy complains about missing `body` arg, which is fully optional here
+        op_res = self.run_client.projects().locations().operations().wait(name=op_name).execute() # type: ignore[call-arg]
 
         if "error" in op_res:
             raise RuntimeError(f"Cloud Run deployment failed: {op_res['error']}")

--- a/sebs/gcp/gcp.py
+++ b/sebs/gcp/gcp.py
@@ -1437,7 +1437,13 @@ class RunContainerStrategy(DeploymentStrategy):
         op_name = self._operation_response["name"]
         self.logging.info(f"Waiting for operation: {op_name}")
         # mypy complains about missing `body` arg, which is fully optional here
-        op_res = self.run_client.projects().locations().operations().wait(name=op_name).execute() # type: ignore[call-arg]
+        op_res = (
+            self.run_client.projects()
+            .locations()
+            .operations()
+            .wait(name=op_name)  # type: ignore[call-arg]
+            .execute()
+        )
 
         if "error" in op_res:
             raise RuntimeError(f"Cloud Run deployment failed: {op_res['error']}")


### PR DESCRIPTION
Previously, we fetched an 800px thumbnail of an image from Wikipedia. Now, we can only use a subset of thumbnail sizes; 960px is the closest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the benchmark’s supported input types (`test`, `small`, `large`) and what content each option downloads/fetches.

* **Bug Fixes**
  * Updated the `test` input’s download URL and corresponding expected checksum to match the new referenced image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->