### PR TITLE
Fix Pillow version for 504.dna-visualisation

### DIFF
--- a/benchmarks/500.scientific/504.dna-visualisation/python/requirements.txt.3.11
+++ b/benchmarks/500.scientific/504.dna-visualisation/python/requirements.txt.3.11
@@ -4,3 +4,4 @@ squiggle==0.3.1
 # we have to fix version to prevent compilation from source
 numpy==2.2.6
 contourpy==1.3.2
+pillow==10.3.0


### PR DESCRIPTION
One of the dependencies tries to install Pillow version that does not have wheels for Python 3.11