### PR TITLE
aws: update lambda images to AL2023

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -21,6 +21,14 @@ jobs:
             version: "3.11"
             architecture: "arm64"
           - platform: aws
+            language: python
+            version: "3.12"
+            architecture: "x64"
+          - platform: aws
+            language: python
+            version: "3.12"
+            architecture: "arm64"
+          - platform: aws
             language: nodejs
             version: "24"
             architecture: "x64"
@@ -39,6 +47,14 @@ jobs:
           - platform: aws
             language: java
             version: "17"
+            architecture: "arm64"
+          - platform: aws
+            language: java
+            version: "21"
+            architecture: "x64"
+          - platform: aws
+            language: java
+            version: "21"
             architecture: "arm64"
           - platform: gcp
             language: python

--- a/configs/systems.json
+++ b/configs/systems.json
@@ -141,12 +141,16 @@
       "java": {
         "base_images": {
           "x64": {
-            "17": "amazon/aws-lambda-java:17.2026.02.28.00-x86_64",
-            "11": "amazon/aws-lambda-java:11.2026.02.28.00-x86_64"
+            "25": "amazon/aws-lambda-java:25.2026.07.31.14-x86_64",
+            "21": "amazon/aws-lambda-java:21.2026.07.31.14-x86_64",
+            "17": "amazon/aws-lambda-java:17.2026.07.31.14-x86_64",
+            "11": "amazon/aws-lambda-java:11.2026.07.31.14-x86_64"
           },
           "arm64": {
-            "17": "amazon/aws-lambda-java:17.2026.02.28.00-arm64",
-            "11": "amazon/aws-lambda-java:11.2026.02.28.00-arm64"
+            "25": "amazon/aws-lambda-java:25.2026.07.31.14-arm64",
+            "21": "amazon/aws-lambda-java:21.2026.07.31.14-arm64",
+            "17": "amazon/aws-lambda-java:17.2026.07.31.14-arm64",
+            "11": "amazon/aws-lambda-java:11.2026.07.31.14-arm64"
           }
         },
         "images": [

--- a/configs/systems.json
+++ b/configs/systems.json
@@ -83,14 +83,18 @@
       "python": {
         "base_images": {
           "x64": {
-            "3.11": "amazon/aws-lambda-python:3.11.2024.05.23.18",
-            "3.10": "amazon/aws-lambda-python:3.10.2024.06.19.12",
-            "3.9": "amazon/aws-lambda-python:3.9.2024.05.21.00"
+            "3.14": "amazon/aws-lambda-python:3.14.2026.07.31.13-x86_64",
+            "3.13": "amazon/aws-lambda-python:3.13.2026.07.31.13-x86_64",
+            "3.12": "amazon/aws-lambda-python:3.12.2026.07.31.13-x86_64",
+            "3.11": "amazon/aws-lambda-python:3.11.2026.07.31.13-x86_64",
+            "3.10": "amazon/aws-lambda-python:3.10.2026.07.31.13-x86_64"
           },
           "arm64": {
-            "3.11": "amazon/aws-lambda-python:3.11.2024.05.23.17",
-            "3.10": "amazon/aws-lambda-python:3.10.2024.06.19.11",
-            "3.9": "amazon/aws-lambda-python:3.9.2024.05.20.23"
+            "3.14": "amazon/aws-lambda-python:3.14.2026.07.31.13-arm64",
+            "3.13": "amazon/aws-lambda-python:3.13.2026.07.31.13-arm64",
+            "3.12": "amazon/aws-lambda-python:3.12.2026.07.31.13-arm64",
+            "3.11": "amazon/aws-lambda-python:3.11.2026.07.31.13-arm64",
+            "3.10": "amazon/aws-lambda-python:3.10.2026.07.31.13-arm64"
           }
         },
         "images": [

--- a/dockerfiles/aws/java/Dockerfile.build
+++ b/dockerfiles/aws/java/Dockerfile.build
@@ -5,7 +5,14 @@ ENV JAVA_VERSION=${VERSION}
 ARG TARGETARCH
 
 # useradd, groupmod, build tooling
-RUN dnf install -y shadow-utils unzip tar gzip zip
+RUN if command -v dnf >/dev/null 2>&1; then \
+      dnf install -y findutils shadow-utils unzip tar gzip zip && dnf clean all; \
+    elif command -v yum >/dev/null 2>&1; then \
+      yum install -y findutils shadow-utils unzip tar gzip zip && yum clean all; \
+    else \
+      echo "No supported package manager found" >&2; \
+      exit 1; \
+    fi
 # Install Maven 3.x (maven package may be old, install from Apache directly)
 RUN curl -fsSL https://archive.apache.org/dist/maven/maven-3/3.9.6/binaries/apache-maven-3.9.6-bin.tar.gz | tar -xz -C /opt && \
     ln -s /opt/apache-maven-3.9.6 /opt/maven && \

--- a/dockerfiles/aws/java/Dockerfile.build
+++ b/dockerfiles/aws/java/Dockerfile.build
@@ -5,7 +5,7 @@ ENV JAVA_VERSION=${VERSION}
 ARG TARGETARCH
 
 # useradd, groupmod, build tooling
-RUN yum install -y shadow-utils unzip tar gzip zip
+RUN dnf install -y shadow-utils unzip tar gzip zip
 # Install Maven 3.x (maven package may be old, install from Apache directly)
 RUN curl -fsSL https://archive.apache.org/dist/maven/maven-3/3.9.6/binaries/apache-maven-3.9.6-bin.tar.gz | tar -xz -C /opt && \
     ln -s /opt/apache-maven-3.9.6 /opt/maven && \

--- a/dockerfiles/aws/java/Dockerfile.function
+++ b/dockerfiles/aws/java/Dockerfile.function
@@ -4,7 +4,14 @@ ARG VERSION
 ENV JAVA_VERSION=${VERSION}
 ARG TARGET_ARCHITECTURE
 
-RUN dnf install -y shadow-utils unzip tar gzip zip
+RUN if command -v dnf >/dev/null 2>&1; then \
+      dnf install -y findutils shadow-utils unzip tar gzip zip && dnf clean all; \
+    elif command -v yum >/dev/null 2>&1; then \
+      yum install -y findutils shadow-utils unzip tar gzip zip && yum clean all; \
+    else \
+      echo "No supported package manager found" >&2; \
+      exit 1; \
+    fi
 # Install Maven 3.x (maven package may be old, install from Apache directly)
 RUN curl -fsSL https://archive.apache.org/dist/maven/maven-3/3.9.6/binaries/apache-maven-3.9.6-bin.tar.gz | tar -xz -C /opt && \
     ln -s /opt/apache-maven-3.9.6 /opt/maven && \

--- a/dockerfiles/aws/java/Dockerfile.function
+++ b/dockerfiles/aws/java/Dockerfile.function
@@ -4,7 +4,7 @@ ARG VERSION
 ENV JAVA_VERSION=${VERSION}
 ARG TARGET_ARCHITECTURE
 
-RUN yum install -y shadow-utils unzip tar gzip zip
+RUN dnf install -y shadow-utils unzip tar gzip zip
 # Install Maven 3.x (maven package may be old, install from Apache directly)
 RUN curl -fsSL https://archive.apache.org/dist/maven/maven-3/3.9.6/binaries/apache-maven-3.9.6-bin.tar.gz | tar -xz -C /opt && \
     ln -s /opt/apache-maven-3.9.6 /opt/maven && \

--- a/dockerfiles/aws/python/Dockerfile.build
+++ b/dockerfiles/aws/python/Dockerfile.build
@@ -5,7 +5,14 @@ ENV PYTHON_VERSION=${VERSION}
 ARG TARGETARCH
 
 # useradd, groupmod
-RUN yum install -y shadow-utils zip
+RUN if command -v dnf >/dev/null 2>&1; then \
+      dnf install -y findutils shadow-utils zip && dnf clean all; \
+    elif command -v yum >/dev/null 2>&1; then \
+      yum install -y findutils shadow-utils zip && yum clean all; \
+    else \
+      echo "No supported package manager found" >&2; \
+      exit 1; \
+    fi
 ENV GOSU_VERSION 1.14
 # https://github.com/tianon/gosu/releases/tag/1.14
 # key https://keys.openpgp.org/search?q=tianon%40debian.org

--- a/sebs/regression.py
+++ b/sebs/regression.py
@@ -1289,7 +1289,7 @@ def filter_out_benchmarks(
 
     # Filter out image recognition on newer Python versions on AWS
     if (deployment_name == "aws" and language == "python"
-            and language_version in ["3.9", "3.10", "3.11"]
+            and language_version in ["3.10", "3.11", "3.12", "3.13", "3.14"]
             and deployment_type == "package"):
         return "411.image-recognition" not in benchmark
 


### PR DESCRIPTION
Closes #208.

A few notes on this pull request:

- AL2023 is missing `find`, so `findutils` must be installed explicitly. Without it, Dockerfile.function and `java_installer.sh` for Java fails otherwise with:

   ```text
   0.182 /bin/sh: line 1: find: command not found
   ```
 
- AL2023 [also provides Java 11 and Java 17 images](https://docs.aws.amazon.com/lambda/latest/dg/java-image.html#java-image-base). I opted to drop those versions in favor of Java 21 and 25, but can retain them using their `.al2023` variants if so desired.

 - Python 3.9–3.11 were similarly replaced by Python 3.12–3.14. Python 3.11 remains supported, but its standard Lambda base image uses Amazon Linux 2.
  
- The commits are scoped and ordered nicely, but the diff should be trivial enough to review as it is.

<hr>

I've built the following images locally for both x64 and arm64:

- Python builder images: 3.12, 3.13, 3.14
- Java builder images: 21, 25
- Java function images: 21, 25

I also deployed and invoked some benchmarks in `us-east-1` on x64, both as Container and as package:

1. `010.sleep` using Python 3.12
2. `110.dynamic-html` using Java 21

All of them passed `--validate`. 

Please let me know if I should run any additional benchmarks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for AWS Lambda Python versions 3.12–3.14 and Java versions 21 and 25 across x64 and arm64 architectures.
  * Updated AWS Lambda runtime image mappings for supported Python and Java versions.
* **Bug Fixes**
  * Updated regression testing to cover current Python and Java versions.
  * Adjusted benchmark exclusions for newer Python runtimes.
* **Chores**
  * Improved AWS build environments with broader package-manager compatibility and required utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->